### PR TITLE
Teach log commands about the new events endpoint

### DIFF
--- a/tests/commands/execution/test_logs.py
+++ b/tests/commands/execution/test_logs.py
@@ -1,5 +1,4 @@
-import requests_mock
-
+from tests.commands.execution.utils import get_execution_data_mock
 from tests.fixture_data import EXECUTION_DATA
 from valohai_cli.commands.execution.logs import logs
 
@@ -7,11 +6,7 @@ from valohai_cli.commands.execution.logs import logs
 def test_logs(runner, logged_in_and_linked):
     counter = EXECUTION_DATA['counter']
 
-    with requests_mock.mock() as m:
-        m.get('https://app.valohai.com/api/v0/executions/', json={
-            'results': [EXECUTION_DATA],
-        })
-        m.get('https://app.valohai.com/api/v0/executions/{id}/'.format(id=EXECUTION_DATA['id']), json=EXECUTION_DATA)
+    with get_execution_data_mock():
         output = runner.invoke(logs, [str(counter)], catch_exceptions=False).output
         assert 'temmie' in output and 'oh no' in output
         output = runner.invoke(logs, ['--no-stderr', str(counter)], catch_exceptions=False).output

--- a/tests/commands/execution/utils.py
+++ b/tests/commands/execution/utils.py
@@ -1,6 +1,6 @@
 import requests_mock
 
-from tests.fixture_data import EXECUTION_DATA, PROJECT_DATA
+from tests.fixture_data import EXECUTION_DATA, PROJECT_DATA, EVENT_RESPONSE_DATA
 
 
 def get_execution_data_mock():
@@ -8,4 +8,5 @@ def get_execution_data_mock():
     m.get('https://app.valohai.com/api/v0/projects/{id}/'.format(id=PROJECT_DATA['id']), json=PROJECT_DATA)
     m.get('https://app.valohai.com/api/v0/executions/', json={'results': [EXECUTION_DATA]})
     m.get('https://app.valohai.com/api/v0/executions/{id}/'.format(id=EXECUTION_DATA['id']), json=EXECUTION_DATA)
+    m.get('https://app.valohai.com/api/v0/executions/{id}/events/'.format(id=EXECUTION_DATA['id']), json=EVENT_RESPONSE_DATA)
     return m

--- a/tests/fixture_data.py
+++ b/tests/fixture_data.py
@@ -42,18 +42,6 @@ EXECUTION_DATA = {
         'display': 'https://app.valohai.com/p/test/mnist/execution/34/',
         'stop': 'https://app.valohai.com/api/v0/executions/34/stop/',
     },
-    'events': [
-        {
-            'time': '2017-02-16T15:25:33.037000',
-            'stream': 'status',
-            'message': 'hOI!!! I\'m temmie!'
-        },
-        {
-            'time': '2017-02-16T15:25:33.037000',
-            'stream': 'stderr',
-            'message': 'oh no',
-        },
-    ],
     'parameters': {
         'dropout': 0.9,
         'learning_rate': 0.001,
@@ -79,6 +67,23 @@ EXECUTION_DATA = {
         'owner': None,
         'unfinished_job_count': 0,
     },
+}
+
+EVENT_RESPONSE_DATA = {
+    'total': 5,
+    'truncated': False,
+    'events': [
+        {
+            'time': '2017-02-16T15:25:33.037000',
+            'stream': 'status',
+            'message': 'hOI!!! I\'m temmie!'
+        },
+        {
+            'time': '2017-02-16T15:25:33.037000',
+            'stream': 'stderr',
+            'message': 'oh no',
+        },
+    ],
 }
 
 CONFIG_YAML = """

--- a/valohai_cli/log_manager.py
+++ b/valohai_cli/log_manager.py
@@ -1,0 +1,36 @@
+import hashlib
+
+from valohai_cli.api import request
+from valohai_cli.utils import force_bytes
+
+
+class LogManager:
+    def __init__(self, execution):
+        self.execution = execution
+        self.execution_url = execution['url']
+        self.events_url = execution['url'] + 'events/'
+        self.seen_events = set()
+
+    def update_execution(self):
+        self.execution = request('get', self.execution_url).json()
+        return self.execution
+
+    def fetch_events(self, limit=None):
+        params = {}
+        if limit is not None:
+            params['limit'] = limit
+        events_response = request('get', self.events_url, params=params).json()
+        filtered_events = []
+        for event in events_response.get('events', ()):
+            event_id = hashlib.md5(
+                force_bytes('+'.join((event['stream'], event['time'], event['message'])))
+            ).hexdigest()
+            if event_id in self.seen_events:
+                continue
+            self.seen_events.add(event_id)
+            filtered_events.append(event)
+        return {
+            'truncated': events_response.get('truncated', False),
+            'total': events_response.get('total'),
+            'events': filtered_events,
+        }


### PR DESCRIPTION
* Refactor common logic to LogManager
* Teach `vh exec logs` about limits and `--all`
* Make `vh exec watch` read less events