### PR TITLE
Change non existent count parameter to limit

### DIFF
--- a/valohai_cli/commands/environments.py
+++ b/valohai_cli/commands/environments.py
@@ -11,7 +11,7 @@ def environments():
     """
     List all available execution environments.
     """
-    envs_data = request('get', '/api/v0/environments/', params={'count': 9000}).json()['results']
+    envs_data = request('get', '/api/v0/environments/', params={'limit': 9000}).json()['results']
     envs_data.sort(key=itemgetter('name'))
     for env in envs_data:
         if 'per_user_queue_quota' in env and env['per_user_queue_quota'] <= 0:

--- a/valohai_cli/commands/project/link.py
+++ b/valohai_cli/commands/project/link.py
@@ -30,7 +30,7 @@ def choose_project(dir, spec=None):
     :param spec: An optional search string
     :return: project object or None
     """
-    projects = request('get', '/api/v0/projects/', params={'count': '1000'}).json()['results']
+    projects = request('get', '/api/v0/projects/', params={'limit': '1000'}).json()['results']
     if not projects:
         if click.confirm('You don\'t have any projects. Create one instead?'):
             raise NewProjectInstead()

--- a/valohai_cli/commands/project/list.py
+++ b/valohai_cli/commands/project/list.py
@@ -11,6 +11,6 @@ def list():
     """
     List all projects.
     """
-    projects_data = request('get', '/api/v0/projects/', params={'count': 9000}).json()['results']
+    projects_data = request('get', '/api/v0/projects/', params={'limit': 9000}).json()['results']
     projects_data.sort(key=itemgetter('name'))
     print_table(projects_data, ['name', 'description'])


### PR DESCRIPTION
Based on http://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination, `limit` is used as a query parameter instead of `count`.

Before:
```
https://app.valohai.com/api/v0/environments/?count=1
```
![screenshot-app valohai com-2018 05 09-17-42-31](https://user-images.githubusercontent.com/2302748/39824765-6c30d34c-53b0-11e8-828e-a292a8c1fe7e.png)

After:
```
https://app.valohai.com/api/v0/environments/?limit=1
```
![screenshot-app valohai com-2018 05 09-17-42-02](https://user-images.githubusercontent.com/2302748/39824773-716c9eae-53b0-11e8-8836-8ec703d00021.png)

