### PR TITLE
Add a warning about future versions dropping Py2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This is the command-line client for the [Valohai][vh] machine learning IaaS plat
 Installation
 ------------
 
-`valohai-cli` supports Python 2.7 or Python 3.4 and higher. We recommend Python 3.
+`valohai-cli` supports Python 3.5 and higher.
 
 The easiest way to get started is to install `valohai-cli` system-wide with `pip`.
 
 ```bash
-$ pip3 install -U valohai-cli  # (or pip2)
+$ pip3 install -U valohai-cli
 ```
 
 The `-U` flag ensures that any present version is upgraded, too.

--- a/valohai_cli/cli.py
+++ b/valohai_cli/cli.py
@@ -1,7 +1,10 @@
 import logging
+import platform
+import sys
 
 import click
 
+from valohai_cli.messages import warn
 from valohai_cli.plugin_cli import RecursiveHelpPluginCLI
 from valohai_cli.table import TABLE_FORMATS, TABLE_FORMAT_META_KEY
 
@@ -15,3 +18,8 @@ def cli(ctx, debug, table_format):
         logging.basicConfig(level=logging.DEBUG)
     ctx.debug = debug
     ctx.meta[TABLE_FORMAT_META_KEY] = table_format
+    if platform.python_implementation() in ('CPython', 'PyPy') and sys.version_info[:2] < (3, 5):
+        warn(
+            'A future version of the tool will drop support Python versions older than 3.5. '
+            'You are currently using Python %s. Please upgrade!' % platform.python_version()
+        )


### PR DESCRIPTION
We're not yet fully dropping support though, just not mentioning it in the readme anymore.

Refs #64