### PR TITLE
Embetter error formatting

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,15 +1,45 @@
 import pytest
 import requests_mock
+from click._compat import strip_ansi
 
 from valohai_cli.api import request
 from valohai_cli.exceptions import APIError
+from valohai_cli.utils import get_random_string
+from valohai_cli.utils.error_fmt import format_error_data
 
 
 def test_api_error(logged_in, capsys):
+    nonce = get_random_string()
+    message = 'Oh no! ' + nonce
     with requests_mock.mock() as m:
-        m.get('https://app.valohai.com/api/foo/', json={'error': 'Oh no!'}, status_code=406)
+        m.get('https://app.valohai.com/api/foo/', json={'error': message}, status_code=406)
         with pytest.raises(APIError) as aei:
             request('get', 'https://app.valohai.com/api/foo/')
         aei.value.show()
         out, err = capsys.readouterr()
-        assert err.startswith('Error: {"error": "Oh no!"}')
+        assert message in err
+
+
+def test_error_formatter_simple():
+    assert strip_ansi(format_error_data({
+        "environment": [{"message": "Object with slug or primary key bluup does not exist.", "code": "does_not_exist"}]
+    })) == 'environment:\n  * Object with slug or primary key bluup does not exist. (code: does_not_exist)'
+
+
+def test_error_formatter_mixed():
+    assert strip_ansi(format_error_data({
+        "environment": [{"message": "Object with slug or primary key bluup does not exist.", "code": "does_not_exist"}],
+        "non_field_errors": [
+            'oh',
+            'oh no',
+            'that\'s bad',
+            {'message': 'this is fine', 'code': 'dog_not_on_fire'},
+        ],
+    })) == ('''
+* oh
+* oh no
+* that's bad
+* this is fine (code: dog_not_on_fire)
+environment:
+  * Object with slug or primary key bluup does not exist. (code: does_not_exist)
+    ''').strip()

--- a/valohai_cli/api.py
+++ b/valohai_cli/api.py
@@ -47,6 +47,7 @@ class APISession(requests.Session):
         return super(APISession, self).prepare_request(request)
 
     def request(self, method, url, **kwargs):
+        api_error_class = kwargs.pop('api_error_class', APIError)
         handle_errors = bool(kwargs.pop('handle_errors', True))
         try:
             resp = super(APISession, self).request(method, url, **kwargs)
@@ -59,7 +60,7 @@ class APISession(requests.Session):
             raise
 
         if handle_errors and resp.status_code >= 400:
-            cls = (APINotFoundError if resp.status_code == 404 else APIError)
+            cls = (APINotFoundError if resp.status_code == 404 else api_error_class)
             raise cls(resp)
         return resp
 

--- a/valohai_cli/commands/execution/run/__init__.py
+++ b/valohai_cli/commands/execution/run/__init__.py
@@ -1,0 +1,3 @@
+from .frontend_command import run
+
+__all__ = ['run']

--- a/valohai_cli/commands/execution/run/dynamic_run_command.py
+++ b/valohai_cli/commands/execution/run/dynamic_run_command.py
@@ -1,24 +1,15 @@
 import click
-from click.exceptions import BadParameter
-from click.globals import get_current_context
+from click import get_current_context
+from valohai_yaml.objs import Parameter, Step
 from valohai_yaml.objs.input import Input
-from valohai_yaml.objs.parameter import Parameter
-from valohai_yaml.objs.step import Step
 
-import valohai_cli.git as git  # this import style required for tests
-from valohai_cli.adhoc import create_adhoc_commit
+from valohai_cli import git as git
 from valohai_cli.api import request
-from valohai_cli.ctx import get_project
-from valohai_cli.exceptions import NoGitRepo, APIError
-from valohai_cli.utils.api_error_utils import find_error
+from valohai_cli.exceptions import NoGitRepo
+from valohai_cli.messages import success, warn
+from valohai_cli.utils import humanize_identifier, sanitize_option_name
 from valohai_cli.utils.friendly_option_parser import FriendlyOptionParser
-from valohai_cli.messages import success, warn, info
-from valohai_cli.utils import (
-    humanize_identifier,
-    match_prefix,
-    sanitize_option_name,
-    parse_environment_variable_strings,
-)
+from .excs import ExecutionCreationAPIError
 
 
 def generate_sanitized_options(name):
@@ -27,20 +18,6 @@ def generate_sanitized_options(name):
         '--%s' % sanitized_name,
         ('--%s' % sanitized_name).lower(),
     ) if ' ' not in choice)
-
-
-class ExecutionCreationAPIError(APIError):
-    def get_hints(self):
-        try:
-            error_json = self.response.json()
-            assert isinstance(error_json, dict)
-        except:
-            return
-
-        if find_error(error_json.get('environment'), code='does_not_exist'):
-            yield 'Run `{}` to see the complete list of available environments.'.format(
-                click.style('vh environments', bold=True),
-            )
 
 
 class RunCommand(click.Command):
@@ -242,114 +219,3 @@ class RunCommand(click.Command):
         # and just overrides that one piece of behavior...
         parser.__class__ = FriendlyOptionParser
         return parser
-
-
-run_epilog = (
-    'More detailed help (e.g. how to define parameters and inputs) is available when you have '
-    'defined which step to run. For instance, if you have a step called Extract, '
-    'try running `vh exec run Extract --help`.'
-)
-
-
-@click.command(
-    context_settings=dict(ignore_unknown_options=True),
-    add_help_option=False,
-    epilog=run_epilog,
-)
-@click.argument('step')
-@click.option('--commit', '-c', default=None, metavar='SHA', help='The commit to use. Defaults to the current HEAD.')
-@click.option('--environment', '-e', default=None, help='The environment UUID or slug to use (see `vh env`)')
-@click.option('--image', '-i', default=None, help='Override the Docker image specified in the step.')
-@click.option('--title', '-t', default=None, help='Title of the execution.')
-@click.option('--watch', '-w', is_flag=True, help='Start `exec watch`ing the execution after it starts.')
-@click.option('--var', '-v', 'environment_variables', multiple=True, help='Add environment variable (NAME=VALUE). May be repeated.')
-@click.option('--sync', '-s', type=click.Path(file_okay=False), help='Download execution outputs to DIRECTORY.', default=None)
-
-@click.option(
-    '--adhoc',
-    '-a',
-    is_flag=True,
-    help='Upload the current state of the working directory, then run it as an ad-hoc execution.')
-@click.option(
-    '--validate-adhoc/--no-validate-adhoc',
-    help='Enable or disable validation of adhoc packaged code, on by default',
-    default=True,
-)
-@click.argument('args', nargs=-1, type=click.UNPROCESSED)
-@click.pass_context
-def run(ctx, step, commit, environment, watch, sync, title, adhoc, image, environment_variables, validate_adhoc, args):
-    """
-    Start an execution of a step.
-    """
-    if step == '--help':  # This is slightly weird, but it's because of the nested command thing
-        click.echo(ctx.get_help(), color=ctx.color)
-        try:
-            config = get_project(require=True).get_config(commit_identifier=commit)
-            if config.steps:
-                click.echo('\nThese steps are available in the selected commit:\n', color=ctx.color)
-                for step in sorted(config.steps):
-                    click.echo('   * %s' % step, color=ctx.color)
-        except:  # If we fail to extract the step list, it's not that big of a deal.
-            pass
-        ctx.exit()
-    project = get_project(require=True)
-
-    if adhoc:
-        if commit:
-            raise click.UsageError('--commit and --adhoc are mutually exclusive.')
-        if project.is_remote:
-            raise click.UsageError('--adhoc can not be used with remote projects.')
-
-    if sync and watch:
-        raise click.UsageError('Combining --sync and --watch not supported yet.')
-
-    if not commit and project.is_remote:
-        # For remote projects, we need to resolve early.
-        commit = project.resolve_commit()['identifier']
-        info('Using remote project {name}\'s newest commit {commit}'.format(
-            name=project.name,
-            commit=commit,
-        ))
-
-    # We need to pass commit=None when adhoc=True to `get_config`, but
-    # the further steps do need the real commit identifier from remote,
-    # so this is done before `commit` is mangled by `create_adhoc_commit`.
-    config = project.get_config(commit_identifier=commit)
-    matched_step = match_step(config, step)
-    step = config.steps[matched_step]
-
-    rc = RunCommand(
-        project=project,
-        step=step,
-        commit=commit,
-        environment=environment,
-        watch=watch,
-        sync=sync,
-        image=image,
-        title=title,
-        environment_variables=parse_environment_variable_strings(environment_variables),
-    )
-    with rc.make_context(rc.name, list(args), parent=ctx) as child_ctx:
-        if adhoc:
-            rc.commit = create_adhoc_commit(project, validate=validate_adhoc)['identifier']
-        return rc.invoke(child_ctx)
-
-
-def match_step(config, step):
-    if step in config.steps:
-        return step
-    step_matches = match_prefix(config.steps, step, return_unique=False)
-    if not step_matches:
-        raise BadParameter(
-            '"{step}" is not a known step (try one of {steps})'.format(
-                step=step,
-                steps=', '.join(click.style(t, bold=True) for t in sorted(config.steps))
-            ), param_hint='step')
-    if len(step_matches) > 1:
-        raise BadParameter(
-            '"{step}" is ambiguous.\nIt matches {matches}.\nKnown steps are {steps}.'.format(
-                step=step,
-                matches=', '.join(click.style(t, bold=True) for t in sorted(step_matches)),
-                steps=', '.join(click.style(t, bold=True) for t in sorted(config.steps)),
-            ), param_hint='step')
-    return step_matches[0]

--- a/valohai_cli/commands/execution/run/excs.py
+++ b/valohai_cli/commands/execution/run/excs.py
@@ -1,0 +1,18 @@
+import click
+
+from valohai_cli.exceptions import APIError
+from valohai_cli.utils.api_error_utils import find_error
+
+
+class ExecutionCreationAPIError(APIError):
+    def get_hints(self):
+        try:
+            error_json = self.response.json()
+            assert isinstance(error_json, dict)
+        except:
+            return
+
+        if find_error(error_json.get('environment'), code='does_not_exist'):
+            yield 'Run `{}` to see the complete list of available environments.'.format(
+                click.style('vh environments', bold=True),
+            )

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -1,0 +1,89 @@
+import click
+
+from valohai_cli.adhoc import create_adhoc_commit
+from valohai_cli.ctx import get_project
+from valohai_cli.messages import info
+from valohai_cli.utils import parse_environment_variable_strings
+from .dynamic_run_command import RunCommand
+from .utils import match_step
+
+run_epilog = (
+    'More detailed help (e.g. how to define parameters and inputs) is available when you have '
+    'defined which step to run. For instance, if you have a step called Extract, '
+    'try running `vh exec run Extract --help`.'
+)
+
+
+@click.command(
+    context_settings=dict(ignore_unknown_options=True),
+    add_help_option=False,
+    epilog=run_epilog,
+)
+@click.argument('step')
+@click.option('--commit', '-c', default=None, metavar='SHA', help='The commit to use. Defaults to the current HEAD.')
+@click.option('--environment', '-e', default=None, help='The environment UUID or slug to use (see `vh env`)')
+@click.option('--image', '-i', default=None, help='Override the Docker image specified in the step.')
+@click.option('--title', '-t', default=None, help='Title of the execution.')
+@click.option('--watch', '-w', is_flag=True, help='Start `exec watch`ing the execution after it starts.')
+@click.option('--var', '-v', 'environment_variables', multiple=True, help='Add environment variable (NAME=VALUE). May be repeated.')
+@click.option('--sync', '-s', type=click.Path(file_okay=False), help='Download execution outputs to DIRECTORY.', default=None)
+@click.option('--adhoc', '-a', is_flag=True, help='Upload the current state of the working directory, then run it as an ad-hoc execution.')
+@click.option( '--validate-adhoc/--no-validate-adhoc', help='Enable or disable validation of adhoc packaged code, on by default', default=True)
+@click.argument('args', nargs=-1, type=click.UNPROCESSED)
+@click.pass_context
+def run(ctx, step, commit, environment, watch, sync, title, adhoc, image, environment_variables, validate_adhoc, args):
+    """
+    Start an execution of a step.
+    """
+    if step == '--help':  # This is slightly weird, but it's because of the nested command thing
+        click.echo(ctx.get_help(), color=ctx.color)
+        try:
+            config = get_project(require=True).get_config(commit_identifier=commit)
+            if config.steps:
+                click.echo('\nThese steps are available in the selected commit:\n', color=ctx.color)
+                for step in sorted(config.steps):
+                    click.echo('   * %s' % step, color=ctx.color)
+        except:  # If we fail to extract the step list, it's not that big of a deal.
+            pass
+        ctx.exit()
+    project = get_project(require=True)
+
+    if adhoc:
+        if commit:
+            raise click.UsageError('--commit and --adhoc are mutually exclusive.')
+        if project.is_remote:
+            raise click.UsageError('--adhoc can not be used with remote projects.')
+
+    if sync and watch:
+        raise click.UsageError('Combining --sync and --watch not supported yet.')
+
+    if not commit and project.is_remote:
+        # For remote projects, we need to resolve early.
+        commit = project.resolve_commit()['identifier']
+        info('Using remote project {name}\'s newest commit {commit}'.format(
+            name=project.name,
+            commit=commit,
+        ))
+
+    # We need to pass commit=None when adhoc=True to `get_config`, but
+    # the further steps do need the real commit identifier from remote,
+    # so this is done before `commit` is mangled by `create_adhoc_commit`.
+    config = project.get_config(commit_identifier=commit)
+    matched_step = match_step(config, step)
+    step = config.steps[matched_step]
+
+    rc = RunCommand(
+        project=project,
+        step=step,
+        commit=commit,
+        environment=environment,
+        watch=watch,
+        sync=sync,
+        image=image,
+        title=title,
+        environment_variables=parse_environment_variable_strings(environment_variables),
+    )
+    with rc.make_context(rc.name, list(args), parent=ctx) as child_ctx:
+        if adhoc:
+            rc.commit = create_adhoc_commit(project, validate=validate_adhoc)['identifier']
+        return rc.invoke(child_ctx)

--- a/valohai_cli/commands/execution/run/utils.py
+++ b/valohai_cli/commands/execution/run/utils.py
@@ -1,0 +1,24 @@
+import click
+from click import BadParameter
+
+from valohai_cli.utils import match_prefix
+
+
+def match_step(config, step):
+    if step in config.steps:
+        return step
+    step_matches = match_prefix(config.steps, step, return_unique=False)
+    if not step_matches:
+        raise BadParameter(
+            '"{step}" is not a known step (try one of {steps})'.format(
+                step=step,
+                steps=', '.join(click.style(t, bold=True) for t in sorted(config.steps))
+            ), param_hint='step')
+    if len(step_matches) > 1:
+        raise BadParameter(
+            '"{step}" is ambiguous.\nIt matches {matches}.\nKnown steps are {steps}.'.format(
+                step=step,
+                matches=', '.join(click.style(t, bold=True) for t in sorted(step_matches)),
+                steps=', '.join(click.style(t, bold=True) for t in sorted(config.steps)),
+            ), param_hint='step')
+    return step_matches[0]

--- a/valohai_cli/exceptions.py
+++ b/valohai_cli/exceptions.py
@@ -26,8 +26,19 @@ class CLIException(ClickException):
             text = '{kind}: {message}'.format(kind=self.kind, message=formatted_message)
             click.secho(text, file=file, err=True, fg=self.color)
 
+        hints = list(self.get_hints())
+        if hints:
+            click.secho('\nHint:', bold=True, err=True)
+            for hint in hints:
+                click.echo('* {}'.format(hint), err=True)
+
+    def get_hints(self):
+        return []
+
 
 class APIError(CLIException):
+    kind = 'API Error'
+
     def __init__(self, response):
         """
         :type response: requests.Response
@@ -55,11 +66,11 @@ class APIError(CLIException):
 
 
 class APINotFoundError(APIError):
-    pass
+    kind = 'Not Found'
 
 
 class ConfigurationError(CLIException, RuntimeError):
-    pass
+    kind = 'Configuration Error'
 
 
 class NotLoggedIn(ConfigurationError):

--- a/valohai_cli/utils/api_error_utils.py
+++ b/valohai_cli/utils/api_error_utils.py
@@ -1,0 +1,51 @@
+import re
+
+# See Roi for type hints for these functions.
+
+
+def _match_string(str, pattern):
+    if str is None:
+        return False
+    if isinstance(pattern, re.Pattern):
+        return pattern.match(str)
+    return (str == pattern)
+
+
+def match_error(
+    response_data,
+    code=None,
+    message=None,
+    matcher=None,
+):
+    if code and not _match_string(response_data.get('code'), code):
+        return None
+    if message and not _match_string(response_data.get('message'), message):
+        return None
+    if matcher and not matcher(message):
+        return None
+    return response_data
+
+
+def find_error(
+    response_data,
+    code=None,
+    message=None,
+    matcher=None,
+):
+    iterable = None
+    if isinstance(response_data, str):
+        return match_error({'message': response_data, 'code': None}, code=code, message=message, matcher=matcher)
+
+    if isinstance(response_data, dict):
+        if 'code' in response_data and 'message' in response_data:  # Smells like the actual error object
+            return match_error(response_data, code=code, message=message, matcher=matcher)
+        iterable = response_data.values()
+    elif isinstance(response_data, list):
+        iterable = response_data
+
+    if iterable is not None:
+        for value in iterable:
+            rv = find_error(value, code=code, message=message, matcher=matcher)
+            if rv:
+                return rv
+    return None

--- a/valohai_cli/utils/error_fmt.py
+++ b/valohai_cli/utils/error_fmt.py
@@ -1,0 +1,56 @@
+import click
+
+
+class ErrorFormatter:
+    indent = '  '
+    generic_dict_keys = ['non_field_errors', 'detail', 'error']
+
+    def __init__(self):
+        self.buffer = []
+        self.level = 0
+
+    def write(self, prefix, line):
+        indent_str = self.indent * self.level
+        self.buffer.append("{}{}{}".format(indent_str, prefix, line))
+
+    def format(self, data, indent=0, prefix=''):
+        self.level += indent
+        if isinstance(data, dict):
+            if data.get('message'):
+                self.write(prefix, '{message} {styled_code}'.format(
+                    message=data['message'],
+                    styled_code=(
+                        click.style('(code: {code})'.format(code=data.get('code')), dim=True)
+                        if data.get('code')
+                        else ''
+                    ),
+                ))
+            else:
+                self._format_dict(data, prefix=prefix)
+        elif isinstance(data, list):
+            for item in data:
+                self.format(item, prefix='* ')
+        else:
+            self.write(prefix, data)
+        self.level -= indent
+
+    def _format_dict(self, data, prefix):
+        data = data.copy()
+        # Peel off our generic keys first
+        for key in self.generic_dict_keys:
+            value = data.pop(key, None)
+            if value:
+                self.format(value)
+        # Then format the rest
+        for key, value in sorted(data.items()):
+            if isinstance(value, str):
+                self.write(prefix, '{key}: {value}'.format(key=key, value=value))
+            else:
+                self.write(prefix, '{key}:'.format(key=key))
+                self.format(value, indent=1)
+
+
+def format_error_data(data):
+    ef = ErrorFormatter()
+    ef.format(data)
+    return '\n'.join(ef.buffer)


### PR DESCRIPTION
Now that API errors are actual dicts with error codes and all, we can 

* format them in a human-readable way
* dig actionable hints out of them

# Example

<img width="761" alt="Screenshot 2019-04-29 at 15 32 00" src="https://user-images.githubusercontent.com/58669/56896323-12863480-6a94-11e9-8fc3-f442e44e4d2b.png">


Closes #61 (supersedes it)
Fixes valohai/roi#987