### PR TITLE
Correct click version requirement to >= 7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author_email='hait@valohai.com',
     license='MIT',
     install_requires=[
-        'click>=6.0',
+        'click>=7.0',
         'six>=1.10.0',
         'valohai-yaml>=0.8',
         'requests[security]>=2.0.0',


### PR DESCRIPTION
We need the show_envvar kwarg since 1a0f77b33150c02648652e793974f0312a17e7d7.

It was added in pallets/click#710 and released in Click 7.0.