### PR TITLE
Instruct users about token login

### DIFF
--- a/valohai_cli/exceptions.py
+++ b/valohai_cli/exceptions.py
@@ -51,10 +51,29 @@ class APIError(CLIException):
         self.response = response
         self.request = response.request
 
-    def format_message(self):
+    @property
+    def error_json(self):
         try:
             error_json = self.response.json()
             if isinstance(error_json, (dict, list)):
+                return error_json
+        except Exception:
+            return None
+
+    @property
+    def code(self):
+        """
+        Attempt to retrieve a top-level error code from the response.
+        """
+        error_json = self.error_json
+        if error_json:
+            return error_json.get('code')
+        return None
+
+    def format_message(self):
+        try:
+            error_json = self.error_json
+            if error_json:
                 from .utils.error_fmt import format_error_data
                 try:
                     return format_error_data(error_json)

--- a/valohai_cli/messages.py
+++ b/valohai_cli/messages.py
@@ -76,3 +76,18 @@ def error(message, err=True):
 
 def progress(message, err=True):
     click.echo(_format_message(message, PROGRESS_EMOJI, None, None), err=err)
+
+
+DEFAULT_BANNER_STYLE = dict(fg='magenta', bold=True)
+
+
+def banner(message, banner_char='=', banner_style=None):
+    if banner_style is None:
+        banner_style = DEFAULT_BANNER_STYLE
+
+    longest_line_len = max(len(l) for l in message.splitlines())
+
+    banner_line = banner_char * longest_line_len
+    click.secho(banner_line, **banner_style)
+    click.echo(message)
+    click.secho(banner_line, **banner_style)


### PR DESCRIPTION
When we can't use "keyboard-interactive" authentication, e.g. when the user has 2FA or an external identity, we'll show them an instructive 3-step guide instead.

![Screenshot 2019-11-20 at 13 43 21](https://user-images.githubusercontent.com/58669/69236282-dd5e4280-0b9b-11ea-98d0-eedae34725c1.png)
