### PR TITLE
Fix parsing for inputs with a list of defaults

### DIFF
--- a/valohai_cli/commands/execution/run/dynamic_run_command.py
+++ b/valohai_cli/commands/execution/run/dynamic_run_command.py
@@ -133,10 +133,12 @@ class RunCommand(click.Command):
         :rtype: click.Option
         """
         assert isinstance(input, Input)
+        default_as_list = input.default if isinstance(input.default, list) else [input.default]
+
         option = click.Option(
             param_decls=list(generate_sanitized_options(input.name)),
             required=(input.default is None and not input.optional),
-            default=([input.default] if input.default else []),
+            default=(default_as_list if input.default else []),
             metavar='URL',
             multiple=True,
             help='Input "%s"' % humanize_identifier(input.name),


### PR DESCRIPTION
Without this fix, any `valohai.yaml` that has an input with a list of URIs as default fails.

This is because the CLI puts an extra nested array in the payload.

valohai.yaml (without list)
```
inputs:
- default: https://herp.com/training_v2.csv
```
Resulting CLI payload:
```
'inputs': {'training': ('https://herp.com/training_v2.csv',)}
```

valohai.yaml (default is a list)
```
inputs:
- default:
  - https://herp.com/training_v2.csv
```
Resulting CLI payload:
```
{'inputs': {'training': (['https://herp.com/training_v2.csv'],)}}
```

Fails crypticly with:
```
TypeError: argument of type 'NoneType' is not iterable
```