### PR TITLE
Chmod persistence file

### DIFF
--- a/valohai_cli/settings/persistence.py
+++ b/valohai_cli/settings/persistence.py
@@ -1,5 +1,6 @@
 import codecs
 import json
+import os
 from errno import ENOENT
 
 import six
@@ -53,5 +54,11 @@ class FilePersistence(Persistence):
 
     def save(self):
         filename = self.get_filename()
+        first_save = not os.path.isfile(filename)
         with codecs.open(filename, 'w', encoding='UTF-8') as outfp:
             json.dump(self.data, outfp, ensure_ascii=False, indent=2, sort_keys=True)
+        if first_save:
+            try:
+                os.chmod(filename, 0o600)
+            except Exception:
+                pass


### PR DESCRIPTION
When saving a config file for the first time, try making it readable only by the user.

This is done only when the file doesn't pre-exist, to make it possible for users to manually make the file more readable should they require that.