### PR TITLE
Add valohai-utils to requirements.txt

### DIFF
--- a/valohai_cli/commands/yaml/step.py
+++ b/valohai_cli/commands/yaml/step.py
@@ -31,13 +31,13 @@ def step(filenames: List[str]) -> None:
         if not os.path.isfile(config_path):
             update_yaml_from_source(source_path, project)
             info("valohai.yaml generated.")
+            create_or_update_requirements(project)
         elif yaml_needs_update(source_path, project):
             update_yaml_from_source(source_path, project)
             info("valohai.yaml updated.")
+            create_or_update_requirements(project)
         else:
             info("valohai.yaml already up-to-date.")
-
-    create_or_update_requirements(project)
 
 
 def get_current_config(project: Project) -> Optional[Config]:

--- a/valohai_cli/commands/yaml/step.py
+++ b/valohai_cli/commands/yaml/step.py
@@ -114,10 +114,10 @@ def create_or_update_requirements(project: Project) -> None:
 
     if os.path.isfile(requirements_path):
         with open(requirements_path, 'a+') as out_file:
-            if('valohai-utils' not in out_file.read()) :
+            if('valohai-utils' not in out_file.read()):
                 out_file.write("\nvalohai-utils")
                 info("Added valohai-utils to requirements.txt")
-    else :
+    else:
         with open(requirements_path, 'w') as out_file:
             out_file.write("valohai-utils")
             info("requirements.txt generated")

--- a/valohai_cli/commands/yaml/step.py
+++ b/valohai_cli/commands/yaml/step.py
@@ -37,6 +37,8 @@ def step(filenames: List[str]) -> None:
         else:
             info("valohai.yaml already up-to-date.")
 
+    create_or_update_requirements(project)
+
 
 def get_current_config(project: Project) -> Optional[Config]:
     try:
@@ -100,3 +102,22 @@ def yaml_needs_update(source_path: str, project: Project) -> bool:
         return True
 
     return bool(old_config.serialize() != new_config.serialize())
+
+def create_or_update_requirements(project: Project):
+    """ Makes sure valohai-utils is in requiremens.txt file or creates a new requirements.txt with valohai-utils
+
+    :param project: Currently linked Valohai project
+
+    """
+
+    requirements_path = os.path.join(project.directory, "requirements.txt")
+
+    if os.path.isfile(requirements_path):
+        with open(requirements_path, 'a+') as out_file:
+            if('valohai-utils' not in out_file.read()) :
+                out_file.write("\nvalohai-utils")
+                info("Added valohai-utils to requirements.txt")
+    else :
+        with open(requirements_path, 'w') as out_file:
+            out_file.write("valohai-utils")
+            info("requirements.txt generated")

--- a/valohai_cli/commands/yaml/step.py
+++ b/valohai_cli/commands/yaml/step.py
@@ -103,7 +103,7 @@ def yaml_needs_update(source_path: str, project: Project) -> bool:
 
     return bool(old_config.serialize() != new_config.serialize())
 
-def create_or_update_requirements(project: Project):
+def create_or_update_requirements(project: Project) -> None:
     """ Makes sure valohai-utils is in requiremens.txt file or creates a new requirements.txt with valohai-utils
 
     :param project: Currently linked Valohai project


### PR DESCRIPTION
Updating `yaml step` command to make sure `valohai-utils` in is the requirements.txt.

Add a requirements.txt when creating a new step, if there isn't one already
If there is a requirements.txt already, append valohai-utils