### PR TITLE
Replace grave accents with quotes

### DIFF
--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -76,14 +76,14 @@ def test_param_type_validation_integer(runner, logged_in_and_linked):
     with open(get_project().get_config_filename(), 'w') as yaml_fp:
         yaml_fp.write(CONFIG_YAML)
     rv = runner.invoke(run, ['train', '--max-steps=plonk'], catch_exceptions=False)
-    assert 'plonk is not a valid integer' in rv.output
+    assert '\'plonk\' is not a valid integer' in rv.output
 
 
 def test_param_type_validation_flag(runner, logged_in_and_linked):
     with open(get_project().get_config_filename(), 'w') as yaml_fp:
         yaml_fp.write(CONFIG_YAML)
     rv = runner.invoke(run, ['train', '--enable-mega-boost=please'], catch_exceptions=False)
-    assert 'please is not a valid boolean' in rv.output
+    assert '\'please\' is not a valid boolean' in rv.output
 
 
 @pytest.mark.parametrize('value, result', [

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -13,7 +13,7 @@ from .utils import match_step
 run_epilog = (
     'More detailed help (e.g. how to define parameters and inputs) is available when you have '
     'defined which step to run. For instance, if you have a step called Extract, '
-    'try running `vh exec run Extract --help`.'
+    'try running "vh exec run Extract --help".'
 )
 
 
@@ -24,10 +24,10 @@ run_epilog = (
 )
 @click.argument('step', required=False, metavar='STEP-NAME')
 @click.option('--commit', '-c', default=None, metavar='SHA', help='The commit to use. Defaults to the current HEAD.')
-@click.option('--environment', '-e', default=None, help='The environment UUID or slug to use (see `vh env`)')
+@click.option('--environment', '-e', default=None, help='The environment UUID or slug to use (see "vh env")')
 @click.option('--image', '-i', default=None, help='Override the Docker image specified in the step.')
 @click.option('--title', '-t', default=None, help='Title of the execution.')
-@click.option('--watch', '-w', is_flag=True, help='Start `exec watch`ing the execution after it starts.')
+@click.option('--watch', '-w', is_flag=True, help='Start "exec watch"ing the execution after it starts.')
 @click.option('--var', '-v', 'environment_variables', multiple=True, help='Add environment variable (NAME=VALUE). May be repeated.')
 @click.option('--tag', 'tags', multiple=True, help='Tag the execution. May be repeated.')
 @click.option('--sync', '-s', 'download_directory', type=click.Path(file_okay=False), help='Download execution outputs to DIRECTORY.', default=None)

--- a/valohai_cli/commands/init.py
+++ b/valohai_cli/commands/init.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 from typing import Optional
 
@@ -71,7 +72,7 @@ def init() -> None:
         # If we didn't link or create a project, don't show the "all good to go" text.
         return
 
-    width = min(70, click.get_terminal_size()[0])
+    width = min(70, shutil.get_terminal_size()[0])
     click.secho('*' * width, fg='green', bold=True)
     click.echo(DONE_TEXT.strip().format(
         command=click.style('vh exec run --adhoc --watch execute', bold=True),

--- a/valohai_cli/commands/parcel.py
+++ b/valohai_cli/commands/parcel.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -205,7 +206,7 @@ def export_docker_image(image: str, output_path: str, print_progress: bool=True)
                 break
             outfp.write(chunk)
             if print_progress:
-                width = click.get_terminal_size()[0]
+                width = shutil.get_terminal_size()[0]
                 status_text = '{} {}: {} / {}'.format(
                     get_spinner_character(),
                     image,

--- a/valohai_cli/table.py
+++ b/valohai_cli/table.py
@@ -1,8 +1,8 @@
 import json
+import shutil
 import sys
 
 import click
-from click import get_terminal_size
 
 from valohai_cli.settings import settings
 from typing import Union, Tuple, Any, Iterable, Optional, Callable, List, Type, Sequence
@@ -46,7 +46,7 @@ class HumanTableFormatter:
         # Take header lengths into account
         self.column_widths = [max(len(header), col_w) for (header, col_w) in zip(headers, self.column_widths)]
 
-        self.terminal_width = get_terminal_size()[0]
+        self.terminal_width = shutil.get_terminal_size()[0]
 
         self.vertical_format = (sum(self.column_widths) >= self.terminal_width)
 

--- a/valohai_cli/tui.py
+++ b/valohai_cli/tui.py
@@ -1,4 +1,5 @@
 import math
+import shutil
 import time
 from typing import Dict, Any, List, Optional, Callable
 
@@ -103,7 +104,7 @@ class Layout:
 
     def __init__(self) -> None:
         self.rows: List[LayoutElement] = []
-        self.width, self.height = click.get_terminal_size()
+        self.width, self.height = shutil.get_terminal_size()
 
     def add(self, element: LayoutElement) -> 'Layout':
         """
@@ -121,7 +122,7 @@ class Layout:
         """
         Draw the Layout onto screen.
         """
-        self.width, self.height = click.get_terminal_size()
+        self.width, self.height = shutil.get_terminal_size()
         for element in self.rows:
             element.draw()
 


### PR DESCRIPTION
Replace grave accents with quotes in printed help, as it causes issues with reStructuredText used to generate Valohai's official documentation.