### PR TITLE
Embetter login host prompt flow

### DIFF
--- a/tests/commands/test_auth.py
+++ b/tests/commands/test_auth.py
@@ -38,7 +38,11 @@ def test_auth(runner, mode):
                 '-p', m.password,
             ], catch_exceptions=False)
         elif mode == 'interactive':
-            result = runner.invoke(login, input=f'{m.username}\n{m.password}')
+            result = runner.invoke(login, input='\n'.join([
+                '',  # accept default host
+                m.username,  # enter username
+                m.password,  # enter password
+            ]))
         assert 'Logged in' in result.output
         assert settings.token == m.token
 

--- a/valohai_cli/commands/login.py
+++ b/valohai_cli/commands/login.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import click
 from click.exceptions import Exit
+from urllib.parse import urlparse
 
 from valohai_cli import __version__
 from valohai_cli.api import APISession
@@ -29,23 +30,22 @@ Use a login token instead:
 @yes_option
 def login(username: str, password: str, token: Optional[str], host: Optional[str], yes: bool) -> None:
     """Log in into Valohai."""
-    host = (
-        host  # Explicitly set for this command, ...
-        or settings.overrides.get('host')  # ... or from the top-level CLI (or envvar) ...
-        or default_app_host  # ... or the global default
-    )
     if settings.user and settings.token:
-        user = settings.user
-        current_username = user['username']
+        current_username = settings.user['username']
+        current_host = settings.host
         if not yes:
-            message = (
-                'You are already logged in as {username}.\n'
+            click.confirm((
+                f'You are already logged in as {current_username} on {current_host}.\n'
                 'Are you sure you wish to acquire a new token?'
-            ).format(username=current_username)
-            click.confirm(message, abort=True)
+            ), abort=True)
         else:
-            info(f'--yes set: ignoring pre-existing login for {current_username}')
+            info(f'--yes set: ignoring pre-existing login for {current_username} on {current_host}')
 
+    if not (token or username or password or host):
+        # Don't show the banner if this seems like a non-interactive login.
+        click.secho(f'Welcome to Valohai CLI {__version__}!', bold=True)
+
+    host = validate_host(host)
     if token:
         if username or password:
             error('Token is mutually exclusive with username/password')
@@ -54,7 +54,7 @@ def login(username: str, password: str, token: Optional[str], host: Optional[str
     else:
         token = do_user_pass_login(host=host, username=username, password=password)
 
-    click.echo('Verifying API token...')
+    click.echo(f'Verifying API token on {host}...')
 
     with APISession(host, token) as sess:
         user_data = sess.get('/api/v0/users/me/').json()
@@ -69,16 +69,14 @@ def do_user_pass_login(
     username: Optional[str] = None,
     password: Optional[str] = None,
 ) -> str:
-    if not (username or password):
-        click.secho(f'Welcome to Valohai CLI {__version__}!', bold=True)
-        click.echo(f'\nIf you don\'t yet have an account, please create one at {host} first.\n')
+    click.echo(f'\nIf you don\'t yet have an account, please create one at {host} first.\n')
     if not username:
-        username = click.prompt('Username').strip()
+        username = click.prompt(f'{host} - Username').strip()
     else:
         click.echo(f'Username: {username}')
     if not password:
-        password = click.prompt('Password', hide_input=True)
-    click.echo('Retrieving API token...')
+        password = click.prompt(f'{username} on {host} - Password', hide_input=True)
+    click.echo(f'Retrieving API token from {host}...')
     with APISession(host) as sess:
         try:
             token_data = sess.post('/api/v0/get-token/', data={
@@ -94,3 +92,25 @@ def do_user_pass_login(
                     command += f'--host {host}'
                 banner(TOKEN_LOGIN_HELP.format(code=code, host=host, command=command))
             raise
+
+
+def validate_host(host: Optional[str]) -> str:
+    default_host = (
+        settings.overrides.get('host')  # from the top-level CLI (or envvar) ...
+        or default_app_host  # ... or the global default
+    )
+    while True:
+        if not host:
+            host = click.prompt(
+                f'Login hostname? (You can just also accept the default {default_host} by leaving this empty.) ',
+                default=default_host,
+                prompt_suffix=' ',
+                show_default=False,
+            )
+        parsed_host = urlparse(host)
+        if parsed_host.scheme not in ('http', 'https'):
+            error(f'The hostname {host} is not properly formed missing http:// or https://')
+            host = None
+            continue
+        assert isinstance(host, str)
+        return host


### PR DESCRIPTION
With this PR:

* login will ask to verify the login host; one can just hit ENTER to accept the default (app.valohai.com, or whatever had been overridden using the `VALOHAI_HOST` envvar)
* login will not fail if the host (either via arg or interactive prompt) is malformed (not a real base URL)

Fixes #151

# What does it look like?

## default interactive flow + validation

<img width="881" alt="Screenshot 2021-06-09 at 16 55 01" src="https://user-images.githubusercontent.com/58669/121368193-8e295f80-c943-11eb-8338-2de0811a6936.png">

## host defined on command line

<img width="602" alt="Screenshot 2021-06-09 at 16 55 29" src="https://user-images.githubusercontent.com/58669/121368182-8bc70580-c943-11eb-96f3-e7a722f1a326.png">
