### PR TITLE
Pipeline fixes

### DIFF
--- a/valohai_cli/commands/yaml/pipeline.py
+++ b/valohai_cli/commands/yaml/pipeline.py
@@ -6,6 +6,7 @@ from valohai.yaml import config_to_yaml
 from valohai_yaml.objs.config import Config
 
 from valohai_cli.ctx import get_project
+from valohai_cli.exceptions import ConfigurationError
 from valohai_cli.messages import info
 from valohai_cli.models.project import Project
 
@@ -36,8 +37,12 @@ def pipeline(filenames: List[str]) -> None:
 def get_current_config(project: Project) -> Config:
     try:
         return project.get_config()
-    except FileNotFoundError:
-        raise FileNotFoundError("valohai.yaml not found! Can't create a pipeline without preconfigured steps.")
+    except FileNotFoundError as fnfe:
+        valohai_yaml_name = project.get_config_filename()
+        raise ConfigurationError(
+            f"Did not find {valohai_yaml_name}. "
+            f"Can't create a pipeline without preconfigured steps."
+        ) from fnfe
 
 
 def get_updated_config(source_path: str, project: Project) -> Config:

--- a/valohai_cli/commands/yaml/pipeline.py
+++ b/valohai_cli/commands/yaml/pipeline.py
@@ -1,5 +1,4 @@
-import os
-from typing import Optional, List
+from typing import List
 
 import click
 from valohai.internals.pipeline import get_pipeline_from_source
@@ -24,9 +23,7 @@ def pipeline(filenames: List[str]) -> None:
 
     :param filenames: Path(s) of the Python source code files.
     """
-    project = get_project()
-    assert project
-    config_path = project.get_config_filename()
+    project = get_project(require=True)
 
     for source_path in filenames:
         if yaml_needs_update(source_path, project):

--- a/valohai_cli/commands/yaml/pipeline.py
+++ b/valohai_cli/commands/yaml/pipeline.py
@@ -7,7 +7,7 @@ from valohai_yaml.objs.config import Config
 
 from valohai_cli.ctx import get_project
 from valohai_cli.exceptions import ConfigurationError
-from valohai_cli.messages import info
+from valohai_cli.messages import info, error
 from valohai_cli.models.project import Project
 
 
@@ -29,7 +29,16 @@ def pipeline(filenames: List[str]) -> None:
     did_update = False
     for source_path in filenames:
         old_config = get_current_config(project)
-        new_config = get_pipeline_from_source(source_path, old_config)
+        try:
+            new_config = get_pipeline_from_source(source_path, old_config)
+        except Exception:
+            error(
+                f"Retrieving a new pipeline definition for project {project} for {source_path} failed.\n"
+                f"The configuration file in use is {yaml_filename}. "
+                f"See the full traceback below."
+            )
+            raise
+
         merged_config = old_config.merge_with(new_config)
         if old_config.serialize() != merged_config.serialize():
             with open(yaml_filename, 'w') as out_file:

--- a/valohai_cli/commands/yaml/pipeline.py
+++ b/valohai_cli/commands/yaml/pipeline.py
@@ -25,13 +25,20 @@ def pipeline(filenames: List[str]) -> None:
     :param filenames: Path(s) of the Python source code files.
     """
     project = get_project(require=True)
-
+    yaml_filename = project.get_config_filename()
+    did_update = False
     for source_path in filenames:
-        if yaml_needs_update(source_path, project):
-            update_yaml_from_source(source_path, project)
-            info("valohai.yaml updated.")
-        else:
-            info("valohai.yaml already up-to-date.")
+        old_config = get_current_config(project)
+        new_config = get_pipeline_from_source(source_path, old_config)
+        merged_config = old_config.merge_with(new_config)
+        if old_config.serialize() != merged_config.serialize():
+            with open(yaml_filename, 'w') as out_file:
+                out_file.write(config_to_yaml(merged_config))
+            did_update = True
+    if did_update:
+        info(f"{yaml_filename} updated.")
+    else:
+        info(f"{yaml_filename} already up-to-date.")
 
 
 def get_current_config(project: Project) -> Config:
@@ -43,43 +50,3 @@ def get_current_config(project: Project) -> Config:
             f"Did not find {valohai_yaml_name}. "
             f"Can't create a pipeline without preconfigured steps."
         ) from fnfe
-
-
-def get_updated_config(source_path: str, project: Project) -> Config:
-    """Gets pipeline definition from the source_path and merges it with existing config
-
-    :param source_path: Path of the Python source code file containing the pipeline definition
-    :param project: Currently linked Valohai project
-
-    """
-    old_config = get_current_config(project)
-    new_config = get_pipeline_from_source(source_path, old_config)
-    return old_config.merge_with(new_config)
-
-
-def update_yaml_from_source(source_path: str, project: Project) -> bool:
-    """Updates valohai.yaml by parsing the pipeline definition from the source_path
-
-    :param source_path: Path of the Python source code file containing the pipeline definition
-    :param project: Currently linked Valohai project
-
-    """
-    old_config = get_current_config(project)
-    new_config = get_updated_config(source_path, project)
-
-    if old_config != new_config:
-        with open(project.get_config_filename(), 'w') as out_file:
-            out_file.write(config_to_yaml(new_config))
-        return True
-    return False
-
-def yaml_needs_update(source_path: str, project: Project) -> bool:
-    """Checks if valohai.yaml needs updating based on source Python code.
-
-    :param source_path: Path of the Python source code file containing the pipeline definition
-    :param project: Currently linked Valohai project
-
-    """
-    old_config = get_current_config(project)
-    new_config = get_updated_config(source_path, project)
-    return bool(old_config.serialize() != new_config.serialize())


### PR DESCRIPTION
This PR:

* fixes some miscellaneous error messages in the pipeline... pipeline
* makes it so that the pipeline-generating code is only executed once per file (my previous pull request review hadn't taken that into consideration)
* catches exceptions from the pipeline-generating code to prefix them with some context (pending valohai/papi#9 to make the errors even better), see below. (#156)

## example contextful output

```
$ vh yaml pipe xx.py
😢  ERROR: Retrieving a new pipeline definition for project asdf-pipeline-demo for xx.py failed.
The configuration file in use is /Users/akx/build/tensorflow-example/valohai.yaml. See the full traceback below.
Traceback (most recent call last):
  [...]
  File "xx.py", line 8, in main
    extract = pipe.execution("Batch feature extraction")
  File "papi/__init__.py", line 40, in execution
    step_object = self._get_step(step)
  File "papi/__init__.py", line 50, in _get_step
    raise ValueError(f"no such step {name} in config")
ValueError: no such step Batch feature extraction in config
```