### PR TITLE
Version bumps & type fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     license='MIT',
     install_requires=[
         'click>=7.0',
-        'valohai-yaml>=0.9',
-        'valohai-utils>=0.1.7',
+        'valohai-yaml>=0.15.0',
+        'valohai-utils>=0.1.10',
         'requests>=2.0.0',
         'requests-toolbelt>=0.7.1',
         'typing-extensions>=3.7',

--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -81,14 +81,20 @@ def test_param_type_validation_integer(runner, logged_in_and_linked):
     with open(get_project().get_config_filename(), 'w') as yaml_fp:
         yaml_fp.write(CONFIG_YAML)
     rv = runner.invoke(run, ['train', '--max-steps=plonk'], catch_exceptions=False)
-    assert '\'plonk\' is not a valid integer' in rv.output
+    assert (
+        '\'plonk\' is not a valid integer' in rv.output or
+        'plonk is not a valid integer' in rv.output
+    )
 
 
 def test_param_type_validation_flag(runner, logged_in_and_linked):
     with open(get_project().get_config_filename(), 'w') as yaml_fp:
         yaml_fp.write(CONFIG_YAML)
     rv = runner.invoke(run, ['train', '--enable-mega-boost=please'], catch_exceptions=False)
-    assert '\'please\' is not a valid boolean' in rv.output
+    assert (
+        '\'please\' is not a valid boolean' in rv.output or
+        'please is not a valid boolean' in rv.output
+    )
 
 
 @pytest.mark.parametrize('value, result', [

--- a/valohai_cli/models/project.py
+++ b/valohai_cli/models/project.py
@@ -50,9 +50,7 @@ class Project:
 
     def _parse_config(self, config_fp: TextIO, filename: str = '<config file>') -> Config:
         try:
-            config = valohai_yaml.parse(config_fp)
-            config.project = self
-            return config
+            return valohai_yaml.parse(config_fp)
         except OSError as err:
             raise InvalidConfig(f'Could not read {filename}') from err
         except valohai_yaml.ValidationErrors as ves:


### PR DESCRIPTION
This PR:

* bumps the required minimum versions of the valohai-* packages to somewhat newer versions
* increases test compatibility with newer versions of Click that have changed some spellings
* fixes some type errors found by `mypy --strict`