### PR TITLE
Make optional inputs without default work for pipeline runs (fixes #160)

### DIFF
--- a/valohai_cli/commands/pipeline/run/utils.py
+++ b/valohai_cli/commands/pipeline/run/utils.py
@@ -29,7 +29,7 @@ def build_node_template(commit: str, step: Step) -> dict:
         "image": step.image,
         "command": step.command,
         "inputs": {
-            key: step.inputs[key].default for key in list(step.inputs)
+            name: (input.default or []) for (name, input) in step.inputs.items()
         },
         "parameters": {
             key: step.parameters[key].default for key in


### PR DESCRIPTION
The issue is nicely explained in #160 