### PR TITLE
Add transient setting `api_user_agent_prefix`

### DIFF
--- a/valohai_cli/api.py
+++ b/valohai_cli/api.py
@@ -42,13 +42,17 @@ class APISession(requests.Session):
         self.base_netloc = urlparse(self.base_url).netloc
         self.auth = TokenAuth(self.base_netloc, token)
         self.headers['Accept'] = 'application/json'
-        self.headers['User-Agent'] = 'valohai-cli/{version} on {py_version} ({uname})'.format(
-            version=VERSION,
-            uname=';'.join(platform.uname()),
-            py_version=f'{platform.python_implementation()} {platform.python_version()}',
-        )
+
+    def get_user_agent(self) -> str:
+        uname = ';'.join(platform.uname())
+        py_version = f'{platform.python_implementation()} {platform.python_version()}'
+        user_agent = f'valohai-cli/{VERSION} on {py_version} ({uname})'
+        if settings.api_user_agent_prefix:
+            user_agent = f'{settings.api_user_agent_prefix} {user_agent}'
+        return user_agent
 
     def prepare_request(self, request: Request) -> PreparedRequest:
+        request.headers.setdefault('User-Agent', self.get_user_agent())
         url_netloc: str = urlparse(request.url).netloc
         if not url_netloc:
             request.url = urljoin(self.base_url, request.url)

--- a/valohai_cli/commands/yaml/step.py
+++ b/valohai_cli/commands/yaml/step.py
@@ -65,9 +65,8 @@ def get_updated_config(source_path: str, project: Project) -> Config:
     """
     old_config = get_current_config(project)
     new_config = parse_config_from_source(source_path, project.get_config_filename())
-    # See https://github.com/valohai/valohai-utils/issues/70 for the type ignores
     if old_config:
-        return old_config.merge_with(new_config, python_to_yaml_merge_strategy)  # type: ignore
+        return old_config.merge_with(new_config, python_to_yaml_merge_strategy)
     return new_config  # type: ignore
 
 

--- a/valohai_cli/settings/__init__.py
+++ b/valohai_cli/settings/__init__.py
@@ -17,6 +17,7 @@ class Settings:
     # Non-persistent settings and their defaults:
     output_format = 'human'
     override_project = None
+    api_user_agent_prefix = None
 
     def __init__(self, persistence: Optional[Persistence] = None) -> None:
         if not persistence:


### PR DESCRIPTION
This allows downstream library users to modify the user-agent reported by valohai-cli without having to override, like, everything.