### PR TITLE
Use valohai-yaml for pipeline payload generation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     requests>=2.0.0
     typing-extensions>=3.7
     valohai-utils>=0.1.10
-    valohai-yaml>=0.15.0
+    valohai-yaml>=0.21.1
 
 [options.entry_points]
 console_scripts =

--- a/valohai_cli/commands/pipeline/run/run.py
+++ b/valohai_cli/commands/pipeline/run/run.py
@@ -1,12 +1,13 @@
 import contextlib
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import click
 from click import Context
 from valohai_yaml.objs import Config, Pipeline
+from valohai_yaml.pipelines.conversion import PipelineConverter
 
 from valohai_cli.api import request
-from valohai_cli.commands.pipeline.run.utils import build_edges, build_nodes, match_pipeline
+from valohai_cli.commands.pipeline.run.utils import match_pipeline
 from valohai_cli.ctx import get_project
 from valohai_cli.messages import success
 from valohai_cli.utils.commits import create_or_resolve_commit
@@ -62,13 +63,10 @@ def start_pipeline(
     commit: str,
     title: Optional[str] = None,
 ) -> None:
-    edges = build_edges(pipeline)
-    nodes = build_nodes(commit, config, pipeline)
-    payload = {
-        "edges": edges,
-        "nodes": nodes,
+    payload: Dict[str, Any] = {
         "project": project_id,
         "title": title or pipeline.name,
+        **PipelineConverter(config=config, commit_identifier=commit).convert_pipeline(pipeline),
     }
 
     resp = request(

--- a/valohai_cli/commands/pipeline/run/utils.py
+++ b/valohai_cli/commands/pipeline/run/utils.py
@@ -1,60 +1,7 @@
-from typing import List
-
 import click
-from valohai_yaml.objs import Config, ExecutionNode, Pipeline, Step
+from valohai_yaml.objs import Config
 
 from valohai_cli.utils import match_prefix
-
-
-def build_nodes(commit: str, config: Config, pipeline: Pipeline) -> List[dict]:
-    nodes = []
-    for node in pipeline.nodes:
-        if isinstance(node, ExecutionNode):
-            step = config.steps[node.step]
-            template = build_node_template(commit, step)
-            nodes.append({
-                "name": node.name,
-                "type": node.type,
-                "template": template,
-            })
-            continue
-        raise NotImplementedError(f"{node.type} nodes are not supported by the CLI at present")
-    return nodes
-
-
-def build_node_template(commit: str, step: Step) -> dict:
-    template = {
-        "commit": commit,
-        "step": step.name,
-        "image": step.image,
-        "command": step.command,
-        "inputs": {
-            name: (input.default or []) for (name, input) in step.inputs.items()
-        },
-        "parameters": {
-            key: step.parameters[key].default for key in
-            list(step.parameters)
-        },
-        "inherit_environment_variables": True,
-        "environment_variables": dict(step.environment_variables),
-    }
-    if step.environment:
-        template["environment"] = step.environment
-    return template
-
-
-def build_edges(pipeline: Pipeline) -> List[dict]:
-    return [
-        {
-            "source_node": edge.source_node,
-            "source_key": edge.source_key,
-            "source_type": edge.source_type,
-            "target_node": edge.target_node,
-            "target_type": edge.target_type,
-            "target_key": edge.target_key,
-        }
-        for edge in pipeline.edges
-    ]
 
 
 def match_pipeline(config: Config, pipeline_name: str) -> str:


### PR DESCRIPTION
Following https://github.com/valohai/valohai-yaml/pull/61, valohai-yaml has the canonical code to convert a pipeline definition to a payload.