### PR TITLE
Allow creating adhoc commits with a nonstandard yaml path

### DIFF
--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -96,7 +96,7 @@ def test_param_type_validation_integer(runner, logged_in_and_linked, patch_git, 
     )
 
 
-def test_param_type_validation_flag(runner, logged_in_and_linked, patch_git):
+def test_param_type_validation_flag(runner, logged_in_and_linked, patch_git, default_run_api_mock):
     with open(get_project().get_config_filename(), 'w') as yaml_fp:
         yaml_fp.write(CONFIG_YAML)
     rv = runner.invoke(run, ['train', '--enable-mega-boost=please'], catch_exceptions=False)
@@ -137,7 +137,7 @@ def test_run_no_git(runner, logged_in_and_linked):
         assert 'is not a Git repository' in output
 
 
-def test_param_input_sanitization(runner, logged_in_and_linked, patch_git):
+def test_param_input_sanitization(runner, logged_in_and_linked, patch_git, default_run_api_mock):
     with open(get_project().get_config_filename(), 'w') as yaml_fp:
         yaml_fp.write('''
 - step:
@@ -160,7 +160,7 @@ def test_param_input_sanitization(runner, logged_in_and_linked, patch_git):
     assert '--ridiculously-complex-input-name' in output
 
 
-def test_typo_check(runner, logged_in_and_linked, patch_git):
+def test_typo_check(runner, logged_in_and_linked, patch_git, default_run_api_mock):
     with open(get_project().get_config_filename(), 'w') as yaml_fp:
         yaml_fp.write(CONFIG_YAML)
     args = ['train', '--max-setps=80']  # Oopsy!
@@ -177,7 +177,7 @@ def test_run_help(runner, logged_in_and_linked):
     assert 'Train model' in output
 
 
-def test_command_help(runner, logged_in_and_linked, patch_git):
+def test_command_help(runner, logged_in_and_linked, patch_git, default_run_api_mock):
     with open(get_project().get_config_filename(), 'w') as yaml_fp:
         yaml_fp.write(CONFIG_YAML)
 

--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -86,7 +86,7 @@ def test_run_params(tmpdir, run_test_setup, pass_param):
     run_test_setup.run()
 
 
-def test_param_type_validation_integer(runner, logged_in_and_linked, patch_git):
+def test_param_type_validation_integer(runner, logged_in_and_linked, patch_git, default_run_api_mock):
     with open(get_project().get_config_filename(), 'w') as yaml_fp:
         yaml_fp.write(CONFIG_YAML)
     rv = runner.invoke(run, ['train', '--max-steps=plonk'], catch_exceptions=False)

--- a/tests/commands/project/utils.py
+++ b/tests/commands/project/utils.py
@@ -8,6 +8,7 @@ from valohai_cli.utils import get_random_string
 
 def get_project_mock(create_project_name=None, existing_projects=None):
     username = get_random_string()
+    project_id = uuid4()
     m = requests_mock.mock()
     if isinstance(existing_projects, int):
         existing_projects = get_project_list_data([get_random_string() for x in range(existing_projects)])
@@ -15,7 +16,7 @@ def get_project_mock(create_project_name=None, existing_projects=None):
         m.get('https://app.valohai.com/api/v0/projects/', json=existing_projects)
     if create_project_name:
         m.post('https://app.valohai.com/api/v0/projects/', json=lambda request, context: {
-            'id': str(uuid4()),
+            'id': str(project_id),
             'name': create_project_name,
             'owner': {
                 'id': 8,
@@ -23,4 +24,8 @@ def get_project_mock(create_project_name=None, existing_projects=None):
             }
         })
     m.get('https://app.valohai.com/api/v0/projects/ownership_options/', json=[username])
+    m.get(f'https://app.valohai.com/api/v0/projects/{project_id}/', json={
+        'id': str(project_id),
+        'yaml_path': 'valohai.yaml',
+    })
     return m

--- a/tests/commands/run_test_utils.py
+++ b/tests/commands/run_test_utils.py
@@ -53,6 +53,7 @@ class RunAPIMock(requests_mock.Mocker):
         return {
             'id': self.project_id,
             'name': f'Project {self.project_id}',
+            'yaml_path': 'valohai.yaml',
         }
 
     def handle_commits_list(self, request, context):

--- a/tests/commands/yaml/test_step.py
+++ b/tests/commands/yaml/test_step.py
@@ -5,7 +5,7 @@ from valohai_cli.commands.yaml.step import step
 from valohai_cli.ctx import get_project
 
 
-def test_yaml(runner, logged_in_and_linked):
+def test_yaml(runner, logged_in_and_linked, default_run_api_mock):
     # Try to generate YAML from random .py source code
     source_path = os.path.join(get_project().directory, 'mysnake.py')
     with open(source_path, 'w') as python_fp:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from click.testing import CliRunner
 
+from tests.commands.run_test_utils import RunAPIMock
 from tests.fixture_data import LOGGED_IN_DATA, PROJECT_DATA
 from valohai_cli.settings import settings
 from valohai_cli.settings.persistence import Persistence
@@ -35,3 +36,9 @@ def isolate_cli(tmpdir, monkeypatch):
     project_dir = str(tmpdir.mkdir('proj'))
     monkeypatch.setenv('VALOHAI_CONFIG_DIR', config_dir)
     monkeypatch.setenv('VALOHAI_PROJECT_DIR', project_dir)
+
+
+@pytest.fixture()
+def default_run_api_mock():
+    with RunAPIMock(PROJECT_DATA['id'], 'f' * 16, {}) as am:
+        yield am

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -66,6 +66,7 @@ def run(
         ctx.exit()
         return
     project = get_project(require=True)
+    project.refresh_details()
 
     if download_directory and watch:
         raise click.UsageError('Combining --sync and --watch not supported yet.')

--- a/valohai_cli/commands/lint.py
+++ b/valohai_cli/commands/lint.py
@@ -43,8 +43,13 @@ def lint(filenames: List[str]) -> None:
     """
     if not filenames:
         project = get_project()
+        if project:
+            project.refresh_details()
+            yaml_path = project.get_yaml_path()
+        else:
+            yaml_path = 'valohai.yaml'
         directory = (project.directory if project else get_project_directory())
-        config_file = os.path.join(directory, 'valohai.yaml')
+        config_file = os.path.join(directory, yaml_path)
         if not os.path.exists(config_file):
             raise CLIException(f'There is no {config_file} file. Pass in the names of configuration files to lint?')
         filenames = [config_file]

--- a/valohai_cli/commands/yaml/step.py
+++ b/valohai_cli/commands/yaml/step.py
@@ -85,6 +85,7 @@ def update_yaml_from_source(source_path: str, project: Project) -> bool:
     old_config = get_current_config(project)
     new_config = get_updated_config(source_path, project)
     if old_config != new_config:
+        project.refresh_details()
         with open(project.get_config_filename(), 'w') as out_file:
             out_file.write(config_to_yaml(new_config))
         return True

--- a/valohai_cli/models/project.py
+++ b/valohai_cli/models/project.py
@@ -60,7 +60,11 @@ class Project:
             ))
 
     def get_config_filename(self) -> str:
-        return os.path.join(self.directory, 'valohai.yaml')
+        return os.path.join(self.directory, self.get_yaml_path())
+
+    def get_yaml_path(self) -> str:
+        # Make sure the older API versions that don't expose yaml_path don't completely break
+        return self.data.get('yaml_path', 'valohai.yaml')
 
     def get_execution_from_counter(
         self,
@@ -138,6 +142,16 @@ class Project:
                 return data
 
         raise ValueError(f'No commit found for commit {identifier}')
+
+    def refresh_details(self) -> None:
+        """
+        Refresh the project details from the API.
+        """
+        data = request(
+            'get',
+            f'/api/v0/projects/{self.id}/',
+        ).json()
+        self.data.update(data)
 
     def __str__(self) -> str:
         return self.name

--- a/valohai_cli/packager.py
+++ b/valohai_cli/packager.py
@@ -53,11 +53,11 @@ class VhIgnoreUsage(Enum):
     VHIGNORE = 1
 
 
-def package_directory(dir: str, progress: bool = False, validate: bool = True) -> str:
-    file_stats = get_files_for_package(dir)
+def package_directory(*, directory: str, yaml_path: str, progress: bool = False, validate: bool = True) -> str:
+    file_stats = get_files_for_package(directory)
 
-    if validate and 'valohai.yaml' not in file_stats:
-        raise ConfigurationError(f'valohai.yaml missing from {dir}')
+    if validate and yaml_path not in file_stats:
+        raise ConfigurationError(f'configuration file {yaml_path} missing from {directory}')
 
     if validate:
         package_size_warnings = validate_package_size(file_stats)


### PR DESCRIPTION
- When creating an adhoc commit, ask roi what the yaml path of that project is and send that path over to `import_package` in roi

Fixes valohai/roi#3953