### PR TITLE
Allow custom yaml paths when adhocing

### DIFF
--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 
-from tests.commands.run_test_utils import RunAPIMock, RunTestSetup
+from tests.commands.run_test_utils import ALTERNATIVE_YAML, RunAPIMock, RunTestSetup
 from tests.fixture_data import CONFIG_YAML, PROJECT_DATA
 from valohai_cli.commands.execution.run import run
 from valohai_cli.ctx import get_project
@@ -56,6 +56,19 @@ def test_run_tags(run_test_setup):
     run_test_setup.args.extend(['--tag=bark', '--tag=bork', '--tag=vuh', '--tag=hau'])
     run_test_setup.values['tags'] = ['bark', 'bork', 'vuh', 'hau']
     run_test_setup.run()
+
+
+def test_run_with_yaml_path(run_test_setup):
+    run_test_setup.args.remove('train')
+    # Use a step which is only present in the evaluation YAML
+    run_test_setup.args.append('batch feature extraction')
+    run_test_setup.args.append(f'--yaml={ALTERNATIVE_YAML}')
+    output = run_test_setup.run(verify_adhoc=run_test_setup.adhoc)
+    # Adhoc success case already verified in `run()
+    if not run_test_setup.adhoc:
+        assert '--yaml can only be used with --adhoc' in output
+    else:
+        assert f'from configuration YAML at {ALTERNATIVE_YAML}' in output
 
 
 def test_run_input(run_test_setup):

--- a/tests/commands/pipeline/test_run.py
+++ b/tests/commands/pipeline/test_run.py
@@ -11,7 +11,7 @@ from valohai_cli.ctx import get_project
 def test_pipeline_run_success(runner, logged_in_and_linked):
     add_valid_pipeline_yaml()
     args = ['training']
-    with RunAPIMock(PROJECT_DATA.get('id')):
+    with RunAPIMock(PROJECT_DATA['id']):
         output = runner.invoke(run, args).output
     assert 'Success' in output
 
@@ -19,8 +19,17 @@ def test_pipeline_run_success(runner, logged_in_and_linked):
 def test_pipeline_adhoc_run_success(runner, logged_in_and_linked):
     add_valid_pipeline_yaml()
     args = ['--adhoc', 'training']
-    with RunAPIMock(PROJECT_DATA.get('id')):
+    with RunAPIMock(PROJECT_DATA['id']):
         print(run, args)
+        output = runner.invoke(run, args).output
+    assert 'Success' in output
+    assert 'Uploaded ad-hoc code' in output
+
+
+def test_pipeline_adhoc_with_yaml_path_run_success(runner, logged_in_and_linked):
+    add_valid_pipeline_yaml(yaml_path='bark.yaml')
+    args = ['--adhoc', '--yaml=bark.yaml', 'training']
+    with RunAPIMock(PROJECT_DATA['id']):
         output = runner.invoke(run, args).output
     assert 'Success' in output
     assert 'Uploaded ad-hoc code' in output
@@ -29,7 +38,7 @@ def test_pipeline_adhoc_run_success(runner, logged_in_and_linked):
 def test_pipeline_run_no_name(runner, logged_in_and_linked):
     add_valid_pipeline_yaml()
     args = ['']
-    with RunAPIMock(PROJECT_DATA.get('id')):
+    with RunAPIMock(PROJECT_DATA['id']):
         output = runner.invoke(run, args).output
     assert 'Usage: ' in output
 
@@ -48,6 +57,8 @@ def test_match_pipeline_ambiguous(runner, logged_in_and_linked):
         match_pipeline(config, 'Train')
 
 
-def add_valid_pipeline_yaml():
-    with open(get_project().get_config_filename(), 'w') as yaml_fp:
+def add_valid_pipeline_yaml(yaml_path=None):
+    project = get_project()
+    config_filename = project.get_config_filename(yaml_path=yaml_path)
+    with open(config_filename, 'w') as yaml_fp:
         yaml_fp.write(PIPELINE_YAML)

--- a/tests/commands/yaml/test_pipeline.py
+++ b/tests/commands/yaml/test_pipeline.py
@@ -1,5 +1,8 @@
 import os
 
+import pytest
+
+from tests.commands.yaml.utils import build_args
 from tests.fixture_data import (
     PYTHON_SOURCE,
     PYTHON_SOURCE_DEFINING_PIPELINE,
@@ -10,40 +13,44 @@ from valohai_cli.commands.yaml.pipeline import pipeline
 from valohai_cli.ctx import get_project
 
 
-def test_pipeline(runner, logged_in_and_linked):
+@pytest.mark.parametrize('yaml_path', ['bark.yaml', None])
+def test_pipeline(runner, logged_in_and_linked, yaml_path):
     # Create config with only two steps
-    config_path = os.path.join(get_project().directory, 'valohai.yaml')
+    project = get_project()
+    config_path = project.get_config_filename(yaml_path)
+    yaml_path = yaml_path or project.get_yaml_path()
+
     with open(config_path, 'w') as yaml_fp:
         yaml_fp.write(YAML_WITH_TRAIN_EVAL)
 
     # Try to generate pipeline from random .py source code.
-    source_path = os.path.join(get_project().directory, 'random.py')
+    source_path = os.path.join(project.directory, 'random.py')
     with open(source_path, 'w') as python_fp:
         python_fp.write(PYTHON_SOURCE)
-    args = ([source_path])
+    args = build_args(source_path, yaml_path)
     rv = runner.invoke(pipeline, args, catch_exceptions=True)
     # The .py source was random so we should get an error
     assert isinstance(rv.exception, AttributeError)
 
     # Try generating pipeline from .py source code that is correctly using valohai-utils & papi
-    source_path = os.path.join(get_project().directory, 'mysnake.py')
+    source_path = os.path.join(project.directory, 'mysnake.py')
     with open(source_path, 'w') as python_fp:
         python_fp.write(PYTHON_SOURCE_DEFINING_PIPELINE)
-    args = ([source_path])
+    args = build_args(source_path, yaml_path)
     rv = runner.invoke(pipeline, args, catch_exceptions=True)
     # The current config is missing one of the three steps on purpose. This should raise an exception.
     assert isinstance(rv.exception, ValueError)
 
     # Now re-create config with all the three steps
-    config_path = os.path.join(get_project().directory, 'valohai.yaml')
+    config_path = os.path.join(project.directory, yaml_path)
     with open(config_path, 'w') as yaml_fp:
         yaml_fp.write(YAML_WITH_EXTRACT_TRAIN_EVAL)
 
     # With all the three steps, we are expecting great success
-    args = ([source_path])
+    args = build_args(source_path, yaml_path)
     rv = runner.invoke(pipeline, args, catch_exceptions=False)
-    assert "valohai.yaml updated." in rv.output
+    assert f"{yaml_path} updated." in rv.output
 
     # Try the same update again
     rv = runner.invoke(pipeline, args, catch_exceptions=False)
-    assert "valohai.yaml already up-to-date." in rv.output
+    assert f"{yaml_path} already up-to-date." in rv.output

--- a/tests/commands/yaml/test_step.py
+++ b/tests/commands/yaml/test_step.py
@@ -1,35 +1,40 @@
 import os
 
+import pytest
+
+from tests.commands.yaml.utils import build_args
 from tests.fixture_data import CONFIG_YAML, PYTHON_SOURCE, PYTHON_SOURCE_USING_VALOHAI_UTILS
 from valohai_cli.commands.yaml.step import step
 from valohai_cli.ctx import get_project
 
 
-def test_yaml(runner, logged_in_and_linked, default_run_api_mock):
+@pytest.mark.parametrize('yaml_path', ['bark.yaml', None])
+def test_yaml(runner, logged_in_and_linked, default_run_api_mock, yaml_path):
     # Try to generate YAML from random .py source code
-    source_path = os.path.join(get_project().directory, 'mysnake.py')
+    project = get_project()
+    source_path = os.path.join(project.directory, 'mysnake.py')
+    yaml_path = yaml_path or project.get_yaml_path()
     with open(source_path, 'w') as python_fp:
         python_fp.write(PYTHON_SOURCE)
-    args = ([source_path])
+    args = build_args(source_path, yaml_path)
     rv = runner.invoke(step, args, catch_exceptions=True)
     assert isinstance(rv.exception, ValueError)
 
     # Generate YAML from .py source code that is using valohai-utils
-    source_path = os.path.join(get_project().directory, 'mysnake.py')
     with open(source_path, 'w') as python_fp:
         python_fp.write(PYTHON_SOURCE_USING_VALOHAI_UTILS)
-    args = ([source_path])
+    args = build_args(source_path, yaml_path)
     rv = runner.invoke(step, args, catch_exceptions=False)
-    assert "valohai.yaml generated." in rv.output
+    assert f"{yaml_path} generated." in rv.output
 
     # Update existing YAML from source code
-    config_path = os.path.join(get_project().directory, 'valohai.yaml')
+    config_path = project.get_config_filename(yaml_path=yaml_path)
     with open(config_path, 'w') as yaml_fp:
         yaml_fp.write(CONFIG_YAML)
-    args = ([source_path])
+    args = build_args(source_path, yaml_path)
     rv = runner.invoke(step, args, catch_exceptions=False)
-    assert "valohai.yaml updated." in rv.output
+    assert f"{yaml_path} updated." in rv.output
 
     # Try the same update again
     rv = runner.invoke(step, args, catch_exceptions=False)
-    assert "valohai.yaml already up-to-date." in rv.output
+    assert f"{yaml_path} already up-to-date." in rv.output

--- a/tests/commands/yaml/utils.py
+++ b/tests/commands/yaml/utils.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+
+def build_args(source_path: str, yaml_path: Optional[str] = None) -> list:
+    args = [source_path]
+    if yaml_path:
+        args.append(f'--yaml={yaml_path}')
+    return args

--- a/valohai_cli/adhoc.py
+++ b/valohai_cli/adhoc.py
@@ -14,7 +14,7 @@ from valohai_cli.utils.file_size_format import filesizeformat
 from valohai_cli.utils.hashing import get_fp_sha256
 
 
-def package_adhoc_commit(project: Project, validate: bool = True) -> Dict[str, Any]:
+def package_adhoc_commit(project: Project, validate: bool = True, yaml_path: Optional[str] = None) -> Dict[str, Any]:
     """
     Create an ad-hoc tarball and commit of the project directory.
 
@@ -37,7 +37,7 @@ def package_adhoc_commit(project: Project, validate: bool = True) -> Dict[str, A
         else:
             click.echo(f'Packaging {directory}...')
 
-        yaml_path = project.get_yaml_path()
+        yaml_path = yaml_path or project.get_yaml_path()
         tarball = package_directory(directory=directory, progress=True, validate=validate, yaml_path=yaml_path)
         return create_adhoc_commit_from_tarball(project=project, tarball=tarball, yaml_path=yaml_path, description=description)
     finally:
@@ -109,5 +109,6 @@ def _upload_commit_code(*, project: Project, tarball: str, yaml_path: str, descr
                 data=monitor,
                 headers={'Content-Type': monitor.content_type},
             ).json()
-    success(f"Uploaded ad-hoc code {commit_obj['identifier']}")
+    config_detail = f' from configuration YAML at {yaml_path}' if yaml_path else ''
+    success(f"Uploaded ad-hoc code {commit_obj['identifier']}{config_detail}")
     return commit_obj

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -34,6 +34,7 @@ run_epilog = (
 @click.option('--sync', '-s', 'download_directory', type=click.Path(file_okay=False), help='Download execution outputs to DIRECTORY.', default=None)
 @click.option('--adhoc', '-a', is_flag=True, help='Upload the current state of the working directory, then run it as an ad-hoc execution.')
 @click.option('--validate-adhoc/--no-validate-adhoc', help='Enable or disable validation of adhoc packaged code, on by default', default=True)
+@click.option('--yaml', default=None, help='The path to the configuration YAML (valohai.yaml) file to use.')
 @click.option('--debug-port', type=int)
 @click.option('--debug-key-file', type=click.Path(file_okay=True, readable=True, writable=False))
 @click.argument('args', nargs=-1, type=click.UNPROCESSED, metavar='STEP-OPTIONS...')
@@ -44,6 +45,7 @@ def run(
     adhoc: bool,
     args: List[str],
     commit: Optional[str],
+    yaml: Optional[str],
     download_directory: Optional[str],
     environment: Optional[str],
     environment_variables: List[str],
@@ -82,7 +84,7 @@ def run(
     # We need to pass commit=None when adhoc=True to `get_config`, but
     # the further steps do need the real commit identifier from remote,
     # so this is done before `commit` is mangled by `create_adhoc_commit`.
-    config = project.get_config(commit_identifier=commit)
+    config = project.get_config(commit_identifier=commit, yaml_path=yaml)
     matched_step = match_step(config, step_name)
     step = config.steps[matched_step]
 
@@ -91,6 +93,7 @@ def run(
         commit=commit,
         adhoc=adhoc,
         validate_adhoc_commit=validate_adhoc,
+        yaml_path=yaml,
     )
 
     runtime_config = {}  # type: dict[str, Any]

--- a/valohai_cli/commands/pipeline/run/run.py
+++ b/valohai_cli/commands/pipeline/run/run.py
@@ -21,8 +21,9 @@ from valohai_cli.utils.commits import create_or_resolve_commit
 @click.option('--commit', '-c', default=None, metavar='SHA', help='The commit to use. Defaults to the current HEAD.')
 @click.option('--title', '-c', default=None, help='The optional title of the pipeline run.')
 @click.option('--adhoc', '-a', is_flag=True, help='Upload the current state of the working directory, then run it as an ad-hoc execution.')
+@click.option('--yaml', default=None, help='The path to the configuration YAML file (valohai.yaml) file to use.')
 @click.pass_context
-def run(ctx: Context, name: Optional[str], commit: Optional[str], title: Optional[str], adhoc: bool) -> None:
+def run(ctx: Context, name: Optional[str], commit: Optional[str], title: Optional[str], adhoc: bool, yaml: Optional[str]) -> None:
     """
     Start a pipeline run.
     """
@@ -36,7 +37,10 @@ def run(ctx: Context, name: Optional[str], commit: Optional[str], title: Optiona
     project = get_project(require=True)
     assert project
 
-    commit = create_or_resolve_commit(project, commit=commit, adhoc=adhoc)
+    if yaml and not adhoc:
+        raise click.UsageError('--yaml is only valid with --adhoc')
+
+    commit = create_or_resolve_commit(project, commit=commit, adhoc=adhoc, yaml_path=yaml)
     config = project.get_config()
 
     matched_pipeline = match_pipeline(config, name)

--- a/valohai_cli/commands/yaml/pipeline.py
+++ b/valohai_cli/commands/yaml/pipeline.py
@@ -1,24 +1,23 @@
-from typing import List
+from typing import List, Optional
 
 import click
 from valohai.internals.pipeline import get_pipeline_from_source
 from valohai.yaml import config_to_yaml
-from valohai_yaml.objs.config import Config
 
 from valohai_cli.ctx import get_project
 from valohai_cli.exceptions import ConfigurationError
 from valohai_cli.messages import error, info
-from valohai_cli.models.project import Project
 
 
 @click.command()
+@click.option('--yaml', default=None, help='Path to the YAML file to update.')
 @click.argument(
     "filenames",
     nargs=-1,
     type=click.Path(file_okay=True, exists=True, dir_okay=False),
     required=True,
 )
-def pipeline(filenames: List[str]) -> None:
+def pipeline(filenames: List[str], yaml: Optional[str]) -> None:
     """
     Update a pipeline config(s) in valohai.yaml based on Python source file(s).
     Python source file is expected to have def main(config: Config) -> Pipeline
@@ -30,10 +29,16 @@ def pipeline(filenames: List[str]) -> None:
     :param filenames: Path(s) of the Python source code files.
     """
     project = get_project(require=True)
-    yaml_filename = project.get_config_filename()
+    yaml_filename = project.get_config_filename(yaml_path=yaml)
     did_update = False
     for source_path in filenames:
-        old_config = get_current_config(project)
+        try:
+            old_config = project.get_config(yaml_path=yaml)
+        except FileNotFoundError as fnfe:
+            raise ConfigurationError(
+                f"Did not find {yaml_filename}. "
+                f"Can't create a pipeline without preconfigured steps."
+            ) from fnfe
         try:
             new_config = get_pipeline_from_source(source_path, old_config)
         except Exception:
@@ -53,14 +58,3 @@ def pipeline(filenames: List[str]) -> None:
         info(f"{yaml_filename} updated.")
     else:
         info(f"{yaml_filename} already up-to-date.")
-
-
-def get_current_config(project: Project) -> Config:
-    try:
-        return project.get_config()
-    except FileNotFoundError as fnfe:
-        valohai_yaml_name = project.get_config_filename()
-        raise ConfigurationError(
-            f"Did not find {valohai_yaml_name}. "
-            f"Can't create a pipeline without preconfigured steps."
-        ) from fnfe

--- a/valohai_cli/models/remote_project.py
+++ b/valohai_cli/models/remote_project.py
@@ -8,7 +8,7 @@ from valohai_cli.models.project import Project
 class RemoteProject(Project):
     is_remote = True
 
-    def get_config(self, commit_identifier: Optional[str] = None) -> Config:
+    def get_config(self, commit_identifier: Optional[str] = None, yaml_path: Optional[str] = None) -> Config:  # NOQA U100
         if not commit_identifier:
             raise ValueError('RemoteProjects require an explicit commit identifier')
         commit = self.load_full_commit(commit_identifier)
@@ -16,5 +16,5 @@ class RemoteProject(Project):
             raise ValueError(f'No configuration found for commit {commit_identifier}')
         return self._parse_config(commit['config'], filename='<remote config>')
 
-    def get_config_filename(self) -> str:  # pragma: no cover  # typing: ignore[override]
+    def get_config_filename(self, yaml_path: Optional[str] = None) -> str:  # pragma: no cover  # typing: ignore[override]
         raise NotImplementedError('RemoteProject.get_config_filename() should never get called')

--- a/valohai_cli/utils/commits.py
+++ b/valohai_cli/utils/commits.py
@@ -14,6 +14,7 @@ def create_or_resolve_commit(
     project: Union[RemoteProject, Project],
     *,
     commit: Optional[str],
+    yaml_path: Optional[str],
     adhoc: bool,
     validate_adhoc_commit: bool = True,
 ) -> str:
@@ -22,7 +23,9 @@ def create_or_resolve_commit(
             raise click.UsageError('--adhoc can not be used with remote projects.')
         if commit:
             raise click.UsageError('--commit and --adhoc are mutually exclusive.')
-        commit = str(package_adhoc_commit(project, validate=validate_adhoc_commit)['identifier'])
+        commit = str(package_adhoc_commit(project, validate=validate_adhoc_commit, yaml_path=yaml_path)['identifier'])
+    elif yaml_path:
+        raise click.UsageError('--yaml can only be used with --adhoc.')
 
     commit = commit or get_git_commit(project)
     return resolve_commit(commit, project)


### PR DESCRIPTION
Fixes #193

Add an option `--yaml` to exec, pipeline and yaml creation in order to specify a custom config path.