### PR TITLE
Default to valohai.yaml properly when path in project data is None

### DIFF
--- a/valohai_cli/models/project.py
+++ b/valohai_cli/models/project.py
@@ -67,7 +67,7 @@ class Project:
 
     def get_yaml_path(self) -> str:
         # Make sure the older API versions that don't expose yaml_path don't completely break
-        return self.data.get('yaml_path', 'valohai.yaml')
+        return self.data.get('yaml_path') or 'valohai.yaml'
 
     def get_execution_from_counter(
         self,


### PR DESCRIPTION
When creating a new project via `vh init` the project doesn't have a connected repository in valohai, so the yaml path in the project data is also set as `None`. Let's always make it default to `valohai.yaml`.