### PR TITLE
Add description values to package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,10 @@ name = valohai-cli
 version = attr:valohai_cli.__version__
 author = Valohai
 author_email = hait@valohai.com
+url = https://github.com/valohai/valohai-cli
+description = Command line client for Valohai
+long_description = file:README.md
+long_description_content_type = text/markdown
 license = MIT
 
 [options]


### PR DESCRIPTION
These changes will make the PyPI page more helpful after the next release.

The current information is pretty slim:

![Screenshot from 2022-06-23 11-35-06](https://user-images.githubusercontent.com/2681608/175255023-6fa9b937-4d3b-4f4a-bc36-26bc35fbd8a5.png)
