### PR TITLE
Spot restart

### DIFF
--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -61,7 +61,7 @@ def test_run_tags(run_test_setup):
 def test_run_spot_restart(run_test_setup):
     run_test_setup.args.append('--environment=018161d4-2911-7bbb-85ea-8820559cce89')
     run_test_setup.values['environment'] = '018161d4-2911-7bbb-85ea-8820559cce89'
-    run_test_setup.args.append('--autorestart-spot=True')
+    run_test_setup.args.append('--autorestart')
     run_test_setup.run()
     assert run_test_setup.run_api_mock.last_create_execution_payload["runtime_config"] == {
         'autorestart': True

--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -59,6 +59,8 @@ def test_run_tags(run_test_setup):
 
 
 def test_run_spot_restart(run_test_setup):
+    run_test_setup.args.append('--environment=018161d4-2911-7bbb-85ea-8820559cce89')
+    run_test_setup.values['environment'] = '018161d4-2911-7bbb-85ea-8820559cce89'
     run_test_setup.args.append('--autorestart-spot=True')
     run_test_setup.run()
     assert run_test_setup.run_api_mock.last_create_execution_payload["runtime_config"] == {

--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -59,7 +59,6 @@ def test_run_tags(run_test_setup):
 
 def test_run_spot_restart(run_test_setup):
     run_test_setup.args.append('--autorestart-spot=True')
-    run_test_setup.values['autorestart-spot'] = True
     run_test_setup.run()
     assert run_test_setup.run_api_mock.last_create_execution_payload["runtime_config"] == {
         'autorestart': True

--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -57,6 +57,14 @@ def test_run_tags(run_test_setup):
     run_test_setup.values['tags'] = ['bark', 'bork', 'vuh', 'hau']
     run_test_setup.run()
 
+def test_run_spot_restart(run_test_setup):
+    run_test_setup.args.append('--autorestart-spot=True')
+    run_test_setup.values['autorestart-spot'] = True
+    run_test_setup.run()
+    assert run_test_setup.run_api_mock.last_create_execution_payload["runtime_config"] == {
+        'autorestart': True
+    }
+
 
 def test_run_with_yaml_path(run_test_setup):
     run_test_setup.args.remove('train')

--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -57,6 +57,7 @@ def test_run_tags(run_test_setup):
     run_test_setup.values['tags'] = ['bark', 'bork', 'vuh', 'hau']
     run_test_setup.run()
 
+
 def test_run_spot_restart(run_test_setup):
     run_test_setup.args.append('--autorestart-spot=True')
     run_test_setup.run()

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -37,7 +37,7 @@ run_epilog = (
 @click.option('--yaml', default=None, help='The path to the configuration YAML (valohai.yaml) file to use.')
 @click.option('--debug-port', type=int)
 @click.option('--debug-key-file', type=click.Path(file_okay=True, readable=True, writable=False))
-@click.option('--autorestart-spot', '-r', is_flag=True, help='Enable Automatic Restart on Spot Instance Interruption')
+@click.option('--autorestart/--no-autorestart', help='Enable Automatic Restart on Spot Instance Interruption')
 @click.argument('args', nargs=-1, type=click.UNPROCESSED, metavar='STEP-OPTIONS...')
 @click.pass_context
 def run(
@@ -58,7 +58,7 @@ def run(
     watch: bool,
     debug_port: int,
     debug_key_file: Optional[str],
-    autorestart_spot: bool,
+    autorestart: bool,
 ) -> Any:
     """
     Start an execution of a step.

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -111,8 +111,8 @@ def run(
                     f"does not seem valid (it should start with `ssh`)"
                 )
         runtime_config["debug_key"] = key
-    if autorestart_spot:
-        runtime_config["autorestart"] = autorestart_spot
+    if autorestart:
+        runtime_config["autorestart"] = autorestart
 
     rc = RunCommand(
         project=project,

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -37,6 +37,7 @@ run_epilog = (
 @click.option('--yaml', default=None, help='The path to the configuration YAML (valohai.yaml) file to use.')
 @click.option('--debug-port', type=int)
 @click.option('--debug-key-file', type=click.Path(file_okay=True, readable=True, writable=False))
+@click.option('--autorestart-spot', '-r', is_flag=True, help='Enable Automatic Restart on Spot Instance Interruption')
 @click.argument('args', nargs=-1, type=click.UNPROCESSED, metavar='STEP-OPTIONS...')
 @click.pass_context
 def run(
@@ -57,6 +58,7 @@ def run(
     watch: bool,
     debug_port: int,
     debug_key_file: Optional[str],
+    autorestart_spot: bool,
 ) -> Any:
     """
     Start an execution of a step.
@@ -109,6 +111,8 @@ def run(
                     f"does not seem valid (it should start with `ssh`)"
                 )
         runtime_config["debug_key"] = key
+    if autorestart_spot:
+        runtime_config["autorestart"] = autorestart_spot
 
     rc = RunCommand(
         project=project,


### PR DESCRIPTION
Allow passing `--autorestart_spot` or `-r` when using the spot instances

Fixes #208