### PR TITLE
Create dependabot.yml for version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Refs #216, #217 – let's see if Dependabot can keep us up to date.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates