### PR TITLE
add linebreak before adding valohai-utils to requirements.txt

### DIFF
--- a/valohai_cli/commands/yaml/step.py
+++ b/valohai_cli/commands/yaml/step.py
@@ -130,7 +130,7 @@ def create_or_update_requirements(project: Project) -> None:
             requirements_lines = list(requirements)
 
     if not any('valohai-utils' in line for line in requirements_lines):
-        requirements_lines.append('valohai-utils\n')
+        requirements_lines.append('\nvalohai-utils\n')
         with open(requirements_path, 'w') as requirements:
             requirements.write("".join(requirements_lines))
         info("valohai-utils added to requirements.txt")

--- a/valohai_cli/commands/yaml/step.py
+++ b/valohai_cli/commands/yaml/step.py
@@ -130,7 +130,10 @@ def create_or_update_requirements(project: Project) -> None:
             requirements_lines = list(requirements)
 
     if not any('valohai-utils' in line for line in requirements_lines):
-        requirements_lines.append('\nvalohai-utils\n')
+        if requirements_lines and "\n" not in requirements_lines[-1]:
+            # last line didn't end with a newline, so add one now
+            requirements_lines.append('\n')
+        requirements_lines.append('valohai-utils\n')
         with open(requirements_path, 'w') as requirements:
             requirements.write("".join(requirements_lines))
         info("valohai-utils added to requirements.txt")


### PR DESCRIPTION
Quickfix.. if a customer has a requirements.txt that doesn't end with an empty line we'll append valohai-utils to the end of the last line, instead of creating a new one

```
torch==1.13.0
torchvision==0.14.0
```

There's probably a smorter way to do this :shrug: