### PR TITLE
🧑‍💻🔨 Improve developer experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@
 default:
 	@echo "check README for usage"
 
+.PHONY: dev
+dev:
+	pip install -U pip
+	pip install -r requirements-typecheck.txt
+	pip install -r requirements-lint.txt
+	pip install -r requirements-test.txt
+	pip install -e .
+
 .PHONY: mypy
 mypy:
 	mypy valohai_cli --show-error-code --incremental --strict --disable-error-code=type-arg

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: default
 default:
-	echo "Try another target"
+	@echo "check README for usage"
 
 .PHONY: mypy
 mypy:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
+.PHONY: default
 default:
 	echo "Try another target"
 
+.PHONY: mypy
 mypy:
 	mypy valohai_cli --show-error-code --incremental --strict --disable-error-code=type-arg
 
+.PHONY: lint
 lint:
 	flake8
 
+.PHONY: test
 test:
 	py.test -vvv --cov .

--- a/README.md
+++ b/README.md
@@ -67,16 +67,28 @@ See the [tutorial document](./TUTORIAL.md)!
 
 ## Developing
 
-To work on the `valohai-cli` code: pull the repository, create and activate a virtualenv, then run
+Development requires Python 3.10+; otherwise you'll get false positive type failures.
+CI will run tests on older Python versions.
 
+To work on the `valohai-cli` code: pull the repository, create and activate a virtualenv, then run:
+
+```bash
+make dev
 ```
-pip install -e .
+
+This installs `valohai-cli` as an "editable" `vh` command available in the virtualenv, but linked to 
+the working copy's source. That is, you can now edit the source under `valohai_cli` in your working 
+directory, and try it out with `vh`.
+
+```bash
+vh --help
+# Usage: vh [OPTIONS] COMMAND [ARGS]...
 ```
 
-(The `-e` stands for `--editable`.)
+To run lints, type checks and tests:
 
-This makes a new `vh` command available in the virtualenv, but linked to the working copy's
-source. That is, you can now edit the source under `valohai_cli` in your working directory,
-and try it out with `vh`.
+```bash
+make lint mypy test
+```
 
 [pipx]: https://github.com/pypa/pipx


### PR DESCRIPTION
Slight improvements to `make` targets and README developer guide.

I first tried running the development tooling with Python 3.7 (`mypy` fails to install the listed version) and then 3.8 (type checks give false positives) and jumped to Python 3.10 (based on version used by the CI) which works fine~~

Noted that down in the README.