### PR TITLE
🐛 Allow partial matches when resolving commits

### DIFF
--- a/tests/commands/deployment/test_create_version.py
+++ b/tests/commands/deployment/test_create_version.py
@@ -12,10 +12,10 @@ from valohai_cli.models.project import Project
 def test_create_version(runner, logged_in_and_linked, monkeypatch, name):
     commit_identifier = 'f' * 16
 
-    def mock_resolve_commit(mock_self, *, commit_identifier):
-        return {'identifier': commit_identifier}
+    def mock_resolve_commits(mock_self, *, commit_identifier):
+        return [{'identifier': commit_identifier}]
 
-    monkeypatch.setattr(Project, 'resolve_commit', mock_resolve_commit)
+    monkeypatch.setattr(Project, 'resolve_commits', mock_resolve_commits)
 
     project = get_project()
     apimock_kwargs = {'deployment_version_name': name} if name else {}

--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -17,10 +17,10 @@ def run_test_setup(request, logged_in_and_linked, monkeypatch):
 
 @pytest.fixture()
 def patch_git(monkeypatch):
-    def mock_resolve_commit(mock_self, *, commit_identifier):
-        return {'identifier': commit_identifier}
+    def mock_resolve_commits(mock_self, *, commit_identifier):
+        return [{'identifier': commit_identifier}]
 
-    monkeypatch.setattr(Project, 'resolve_commit', mock_resolve_commit)
+    monkeypatch.setattr(Project, 'resolve_commits', mock_resolve_commits)
 
 
 def test_run_requires_step(runner, logged_in_and_linked):

--- a/tests/test_utils_commits.py
+++ b/tests/test_utils_commits.py
@@ -1,0 +1,91 @@
+import os
+
+import click.exceptions
+import pytest
+import requests_mock
+
+from tests.fixture_data import PROJECT_DATA
+from valohai_cli.models.project import Project
+from valohai_cli.utils.commits import resolve_commit
+
+
+class TestResolveCommit:
+
+    commit_api_url = 'https://app.valohai.com/api/v0/commits/'
+
+    @pytest.fixture
+    def project(self):
+        return Project(data=PROJECT_DATA, directory=os.getcwd())
+
+    @pytest.fixture
+    def commits(self):
+        return [
+            {
+                'commit_time': '2022-11-04T12:32:02Z',  # the oldest
+                'identifier': 'a9f10d48ed9ece3997b40d2432c64eb08bd11e45',
+            },
+            {
+                'commit_time': '2022-11-04T13:33:03Z',  # has ambiguous extension
+                'identifier': 'b5b50f5d183ebc645460dba1329ee48798f31482-alpha',
+            },
+            {
+                'commit_time': '2022-11-04T14:34:04Z',  # has ambiguous extension
+                'identifier': 'b5b50f5d183ebc645460dba1329ee48798f31482-beta',
+            },
+            {
+                'commit_time': '2022-11-04T15:35:05Z',  # has extension
+                'identifier': '8e8351d22cc14e1eeda8c9a5e81320e19eeed3e4-gamma',
+            },
+            {
+                'commit_time': '2022-11-04T16:36:06Z',  # the latest
+                'identifier': 'c243d40ff7feb63aa7e15e8eda1d8859010ebc53',
+            }
+        ]
+
+    @pytest.mark.parametrize('lookup, expected', [
+        # adhoc commit resolves to itself
+        ['~d1df3bdb3614731c4ba795fa3c322617a3c996d9', '~d1df3bdb3614731c4ba795fa3c322617a3c996d9'],
+        # exact match to extensionless commit identifier
+        ['c243d40ff7feb63aa7e15e8eda1d8859010ebc53', 'c243d40ff7feb63aa7e15e8eda1d8859010ebc53'],
+        # partial match to extensionless commit identifier
+        ['c243d40', 'c243d40ff7feb63aa7e15e8eda1d8859010ebc53'],
+        # exact match to commit identifier with an extension
+        ['b5b50f5d183ebc645460dba1329ee48798f31482-alpha', 'b5b50f5d183ebc645460dba1329ee48798f31482-alpha'],
+    ])
+    def test_works(self, capsys, logged_in, project, commits, lookup, expected):
+        with requests_mock.mock() as m:
+            m.get(self.commit_api_url, json={'results': commits})
+            assert resolve_commit(lookup, project=project) == expected
+        out, err = capsys.readouterr()
+        assert not out
+        assert not err
+
+    def test_work_but_warns_if_empty_lookup(self, capsys, logged_in, project, commits):
+        with requests_mock.mock() as m:
+            m.get(self.commit_api_url, json={'results': commits})
+            resolved = resolve_commit('', project=project)
+        assert resolved == 'c243d40ff7feb63aa7e15e8eda1d8859010ebc53'
+        out, err = capsys.readouterr()
+        assert 'Resolved to commit' in err
+        assert 'ambiguous' not in err
+
+    def test_work_but_warns_if_ambiguous(self, capsys, logged_in, project, commits):
+        with requests_mock.mock() as m:
+            m.get(self.commit_api_url, json={'results': commits})
+            # partial match to the latest matching commit identifier with an extension
+            resolved = resolve_commit('b5b50f5d183ebc645460dba1329ee48798f31482', project=project)
+        assert resolved == 'b5b50f5d183ebc645460dba1329ee48798f31482-beta'
+        out, err = capsys.readouterr()
+        assert 'which is ambiguous with' in err
+
+    def test_fails_if_not_found(self, logged_in, project, commits):
+        with requests_mock.mock() as m:
+            m.get(self.commit_api_url, json={'results': commits})
+            with pytest.raises(click.exceptions.Abort):
+                resolve_commit('94c9d70834f53ce765f3b86bac50f015278d8bd4', project)
+
+    def test_fails_if_no_commits(self, logged_in, project):
+        with requests_mock.mock() as m:
+            m.get(self.commit_api_url, json={'results': []})
+            with pytest.raises(click.exceptions.Abort):
+                resolve_commit('c243d40ff7feb63aa7e15e8eda1d8859010ebc53', project)

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -79,7 +79,7 @@ def run(
 
     if not commit and project.is_remote:
         # For remote projects, we need to resolve early.
-        commit = project.resolve_commit()['identifier']
+        commit = project.resolve_commits()[0]['identifier']
         info(f'Using remote project {project.name}\'s newest commit {commit}')
 
     # We need to pass commit=None when adhoc=True to `get_config`, but

--- a/valohai_cli/utils/commits.py
+++ b/valohai_cli/utils/commits.py
@@ -50,7 +50,7 @@ def resolve_commit(commit_identifier: Optional[str], project: Project) -> str:
         return commit_identifier
 
     try:
-        commit_obj = project.resolve_commit(commit_identifier=commit_identifier)
+        matching_commits = project.resolve_commits(commit_identifier=commit_identifier)
     except KeyError:
         warn(f'Commit {commit_identifier} is not known for the project. Have you pushed it?')
         raise click.Abort()
@@ -58,8 +58,15 @@ def resolve_commit(commit_identifier: Optional[str], project: Project) -> str:
         warn('No commits are known for the project.')
         raise click.Abort()
 
+    commit_obj = matching_commits[0]
     resolved_commit_identifier: str = commit_obj['identifier']
-    if not commit_identifier:
+    if len(matching_commits) > 1:
+        ambiguous_str = ", ".join([c['identifier'] for c in matching_commits[1:]])
+        click.echo(
+            f'Resolved to commit {resolved_commit_identifier}, which is ambiguous with {ambiguous_str}',
+            err=True,
+        )
+    elif not commit_identifier:
         click.echo(f'Resolved to commit {resolved_commit_identifier}', err=True)
 
     return resolved_commit_identifier


### PR DESCRIPTION
Valohai commit identifiers are not always git SHAs; they can have YAML path extension.

So using e.g. `vh exec run` in local mode could ask for a commit identifier by git SHA, but the API only lists one with the extension attached. This is a bug 🐛

Allow partial commit identifier matches as `valohai-cli` doesn't know the exact format of the identifiers generated by the API, although the YAML path is generally available.

Tested through the `resolve_commit` helper for slightly better test coverage 🧪

Fixes #241