### PR TITLE
Fix pipx install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This ensures that `valohai-cli`'s dependencies don't conflict with other Python 
 Once you have installed and configured `pipx` (see the link above), you can
 
 ```bash
-$ pipx valohai-cli
+$ pipx install valohai-cli
 ```
 
 and to upgrade it later on,


### PR DESCRIPTION
`pipx valohai-cli` fails with invalid choice for argument command, it requires `pipx install valohai-cli` to work properly.