### PR TITLE
Remove CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Valohai Command Line Client
 
-![CircleCI](https://img.shields.io/github/workflow/status/valohai/valohai-cli/CI.svg)
 ![Codecov](https://img.shields.io/codecov/c/github/valohai/valohai-cli.svg)
 ![PyPI](https://img.shields.io/pypi/v/valohai-cli.svg)
 ![MIT License](https://img.shields.io/github/license/valohai/valohai-cli.svg)


### PR DESCRIPTION
The build badge is broken as CircleCI is no longer in use.

![image](https://user-images.githubusercontent.com/20582490/221104419-ed4c4c00-3967-4133-9571-4087f6948065.png)
