### PR TITLE
Honour --yaml flag to parse configuration in vh pipeline run --adhoc

### DIFF
--- a/tests/commands/pipeline/test_run.py
+++ b/tests/commands/pipeline/test_run.py
@@ -13,17 +13,20 @@ def test_pipeline_run_success(runner, logged_in_and_linked):
     args = ['training']
     with RunAPIMock(PROJECT_DATA['id']):
         output = runner.invoke(run, args).output
+
     assert 'Success' in output
+    assert 'Pipeline =21 queued' in output
 
 
 def test_pipeline_adhoc_run_success(runner, logged_in_and_linked):
     add_valid_pipeline_yaml()
     args = ['--adhoc', 'training']
     with RunAPIMock(PROJECT_DATA['id']):
-        print(run, args)
         output = runner.invoke(run, args).output
+
     assert 'Success' in output
     assert 'Uploaded ad-hoc code' in output
+    assert 'Pipeline =21 queued' in output
 
 
 def test_pipeline_adhoc_with_yaml_path_run_success(runner, logged_in_and_linked):
@@ -31,8 +34,10 @@ def test_pipeline_adhoc_with_yaml_path_run_success(runner, logged_in_and_linked)
     args = ['--adhoc', '--yaml=bark.yaml', 'training']
     with RunAPIMock(PROJECT_DATA['id']):
         output = runner.invoke(run, args).output
+
     assert 'Success' in output
     assert 'Uploaded ad-hoc code' in output
+    assert 'Pipeline =21 queued' in output
 
 
 def test_pipeline_run_no_name(runner, logged_in_and_linked):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,23 @@ def logged_in_and_linked(monkeypatch):
     monkeypatch.setattr(settings, 'persistence', Persistence(data))
 
 
+class PedanticCliRunner(CliRunner):
+    """Override runner.invoke() to let any raised exceptions bubble through,
+    as the default is to catch it.
+
+    Tests can explicitly check exit status if the command failed due to an uncaught exception,
+    but they generally do not do this.
+    """
+    def invoke(self, *args, **kwargs):
+        catch_exceptions = kwargs.pop("catch_exceptions", None)
+        # This flips the default to False
+        catch_exceptions = catch_exceptions is not None
+        return super().invoke(*args, catch_exceptions=catch_exceptions, **kwargs)
+
+
 @pytest.fixture
 def runner():
-    return CliRunner()
+    return PedanticCliRunner()
 
 
 @pytest.fixture(autouse=True)

--- a/valohai_cli/commands/pipeline/run/run.py
+++ b/valohai_cli/commands/pipeline/run/run.py
@@ -50,7 +50,7 @@ def run(
         raise click.UsageError('--yaml is only valid with --adhoc')
 
     commit = create_or_resolve_commit(project, commit=commit, adhoc=adhoc, yaml_path=yaml)
-    config = project.get_config()
+    config = project.get_config(yaml_path=yaml)
 
     matched_pipeline = match_pipeline(config, name)
     pipeline = config.pipelines[matched_pipeline]


### PR DESCRIPTION
Resolves https://github.com/valohai/roi/issues/5071. 

During `vh pipeline run <pipeline> --adhoc`, pipeline steps were resolved on CLI end without honouring the `--yaml` flag for custom configuration. Project default configuration file's steps were used always. We shall now honour the flag. 

This behaviour has an existing test case and the tested code raised an exception as it did not find the default configuration file. However, the default test runner catches exceptions and the test case did not check that the command finished with a successful exit code, nor expected enough output to determine success. These oversights allowed the test to succeed. We will now reraise any exceptions raised during command tests, and pipeline tests will positively assert success up to the API response.

Valohai backend works as expected with CLI initialising its pipeline creation API call using custom configuration.