### PR TITLE
Create a make recipe to run lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,13 @@ default:
 dev:
 	pip install -U pip
 	pip install -r requirements-test.txt
+	pip install pre-commit
 	pip install -e .
+	pre-commit install
+
+.PHONY: lint
+lint:
+	pre-commit run --all-files
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -89,12 +89,8 @@ vh --help
 To run lints, type checks and tests:
 
 ```bash
-# setup development dependencies
-pip install -e . -r requirements-test.txt pre-commit
-pre-commit install
-
 # run linting and type checks
-pre-commit run --all-files
+make lint
 
 # run tests
 make test


### PR DESCRIPTION
Linting still done with pre-commit under the hood. Add pre-commit installation to `make dev` so that a separate installation step is not needed.