### PR TITLE
Require `valohai-yaml>=0.31.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "requests>=2.0.0",
     "typing-extensions>=3.7",
     "valohai-utils>=0.3.0",
-    "valohai-yaml>=0.28.0",
+    "valohai-yaml>=0.31.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Includes pipeline parameter conversion function needed for https://github.com/valohai/valohai-cli/pull/285