### PR TITLE
Require Python 3.8+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         os:
           - ubuntu-20.04
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # Development
 
 ## Setting up
-This project is written in Python 3.7+.
+This project is written in Python 3.8+.
 
 ```bash
 pip install -e .

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ This is the command-line client for the [Valohai][vh] machine learning IaaS plat
 
 ## Installation
 
-`valohai-cli` supports Python 3.7 and higher.
+`valohai-cli` supports Python 3.8 and higher.
 
 If you still need to run on Python 3.5, version 0.13.0 was the last one to support it.
 If you still need to run on Python 3.6, version 0.23.0 was the last one to support it.
+If you still need to run on Python 3.7, version 0.25.0 was the last one to support it.
 
 ### System-wide or user-wide installation with pipx
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Command line client for Valohai"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Valohai", email = "hait@valohai.com" },
 ]
@@ -17,7 +17,6 @@ dependencies = [
     "gitignorant>=0.2.0",
     "requests-toolbelt>=0.7.1",
     "requests>=2.0.0",
-    "typing-extensions>=3.7",
     "valohai-utils>=0.3.0",
     "valohai-yaml>=0.31.0",
 ]
@@ -56,7 +55,7 @@ norecursedirs = [".git", ".tox"]
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py38"
 ignore = [
     "E501",
     "B904",

--- a/valohai_cli/ctx.py
+++ b/valohai_cli/ctx.py
@@ -1,7 +1,6 @@
-from typing import Optional, Union, overload
+from typing import Literal, Optional, Union, overload
 
 import click
-from typing_extensions import Literal
 
 from valohai_cli.exceptions import NoProject
 from valohai_cli.messages import success


### PR DESCRIPTION
Drops the typing-extensions requirement too.