### PR TITLE
Ensure help texts are shown (and all commands have them)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Valohai", email = "hait@valohai.com" },
 ]
 dependencies = [
-    "click>=7.0",
+    "click>=8.0",
     "gitignorant>=0.2.0",
     "requests-toolbelt>=0.7.1",
     "requests>=2.0.0",

--- a/tests/test_cli_descriptions.py
+++ b/tests/test_cli_descriptions.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import pytest
+
+from valohai_cli.cli import cli
+from valohai_cli.consts import json_help_envvar
+
+
+def find_commands_with_no_help(
+    command: dict[str, Any],
+    trail: tuple[dict[str, Any], ...] = (),
+):
+    command_with_trail = (*trail, command)
+    full_command_name = " ".join([c["name"] for c in command_with_trail])
+    if not (
+        full_command_name == "vh" or command.get("hidden") or command.get("deprecated")
+    ):
+        help_text = (command.get("short_help") or command.get("help") or "").strip()
+        if not help_text:
+            yield NotImplementedError(f"Command {full_command_name!r} has no help text")
+    for subcommand in command.get("commands", {}).values():
+        yield from find_commands_with_no_help(subcommand, command_with_trail)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="requires python3.11 or higher",  # (ExceptionGroup)
+)
+def test_all_commands_have_help(runner, monkeypatch):
+    monkeypatch.setenv(json_help_envvar, "1")
+    root_command = json.loads(runner.invoke(cli, ["--help"]).output)["command"]
+    assert root_command["name"] == "cli"
+    root_command["name"] = "vh"  # for easier reading
+    exceptions = list(find_commands_with_no_help(root_command))
+
+    if exceptions:
+        raise ExceptionGroup(
+            f"{len(exceptions)} commands have no help text", exceptions
+        )

--- a/valohai_cli/commands/parcel.py
+++ b/valohai_cli/commands/parcel.py
@@ -56,6 +56,9 @@ def parcel(
     docker_images: bool,
     unparcel_script: bool,
 ) -> None:
+    """
+    Package a project for offline execution. (Experimental)
+    """
     project = get_project(require=True)
 
     if not destination:

--- a/valohai_cli/commands/update_check.py
+++ b/valohai_cli/commands/update_check.py
@@ -10,6 +10,9 @@ from valohai_cli.messages import warn
 
 @click.command()
 def update_check() -> None:
+    """
+    Check if there's a newer version of Valohai-CLI available.
+    """
     data = get_pypi_info()
     current_version = valohai_cli.__version__
     latest_version = data['info']['version']

--- a/valohai_cli/consts.py
+++ b/valohai_cli/consts.py
@@ -25,3 +25,4 @@ complete_execution_statuses = {
 execution_statuses = incomplete_execution_statuses | complete_execution_statuses
 
 default_app_host = 'https://app.valohai.com/'
+json_help_envvar = "VH_CLI_JSON_HELP"

--- a/valohai_cli/plugin_cli.py
+++ b/valohai_cli/plugin_cli.py
@@ -141,7 +141,7 @@ class RecursiveHelpPluginCLI(PluginCLI):
         rows_by_prefix = defaultdict(list)
         for trail, command in self._get_all_commands(ctx):
             prefix = (' '.join(trail[:1]) if len(trail) > 1 else '')
-            help = (command.short_help or command.help or '').partition('\n')[0]
+            help = command.get_short_help_str(90)
             rows_by_prefix[prefix.strip()].append((' '.join(trail).strip(), help))
 
         for prefix, rows in sorted(rows_by_prefix.items()):

--- a/valohai_cli/plugin_cli.py
+++ b/valohai_cli/plugin_cli.py
@@ -1,3 +1,4 @@
+import os
 import pkgutil
 from collections import defaultdict
 from importlib import import_module
@@ -8,6 +9,7 @@ import click
 from click.core import Command, Context
 from click.formatting import HelpFormatter
 
+from valohai_cli.consts import json_help_envvar
 from valohai_cli.utils.cli_utils import join_with_style
 from valohai_cli.utils.matching import match_prefix
 
@@ -124,6 +126,16 @@ def walk_commands(
 
 
 class RecursiveHelpPluginCLI(PluginCLI):
+
+    def get_help(self, ctx: Context) -> str:
+        if os.environ.get(json_help_envvar):
+            # Dump JSON help. The format of this is not guaranteed to be stable,
+            # as (as you can see) it's currently directly provided by Click
+            # (see https://github.com/pallets/click/pull/1623).
+            import json
+            return json.dumps(ctx.to_info_dict())
+
+        return super().get_help(ctx)
 
     def format_commands(self, ctx: Context, formatter: HelpFormatter) -> None:
         rows_by_prefix = defaultdict(list)


### PR DESCRIPTION
The clever idea to use an ExceptionGroup (the other option having been [pytest-check](https://pypi.org/project/pytest-check/)) was courtesy of tpr at koodiklinikka.

Also, turns out the original #279 bug was just a matter of newline padding in the help string; `get_short_help_str` had been added to Click only some time after I'd written the original plugin CLI code, so no wonder we hadn't used it: https://github.com/pallets/click/pull/869

Click 8 is required for `to_info_dict`: https://github.com/pallets/click/pull/1623