### PR TITLE
Give valohai-yaml and valohai-utils a maximum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     "gitignorant>=0.2.0",
     "requests-toolbelt>=0.7.1",
     "requests>=2.0.0",
-    "valohai-utils>=0.3.0",
-    "valohai-yaml>=0.31.0",
+    "valohai-utils>=0.3.0,<0.5.0",
+    "valohai-yaml>=0.31.0,<0.33.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
The additional `valohai.yaml` field to be introduced (https://github.com/valohai/valohai-utils/pull/119) should be added to CLI at a later point.