### PR TITLE
Add `fetch commits` functionality in case of unknown commit

### DIFF
--- a/valohai_cli/api.py
+++ b/valohai_cli/api.py
@@ -72,10 +72,10 @@ class APISession(requests.Session):
         try:
             resp = super().request(method, url, **kwargs)
         except requests.ConnectionError as ce:
-            host = urlparse(ce.request.url).netloc
+            host = urlparse(ce.request.url).netloc if ce.request else self.base_netloc
             if 'Connection refused' in str(ce):
                 raise CLIException(
-                    f'Unable to connect to {host} (connection refused); try again soon.'
+                    f'Unable to connect to {host!r} (connection refused); try again soon.'
                 ) from ce
             raise
 


### PR DESCRIPTION
Resolves #254 

#Why does this pull request exists?
When there is new commits in git repository, cli wont fetch the latest commits and abort by declaring the commit unknown.

##Changes made in PR:
- Fetch latest details when a commit is unknown
- Modified tests according to the case