### PR TITLE
Kubernetes step parsing and command line options

### DIFF
--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -2,7 +2,7 @@ import pytest
 import yaml
 
 from tests.commands.run_test_utils import ALTERNATIVE_YAML, RunAPIMock, RunTestSetup
-from tests.fixture_data import CONFIG_YAML, PROJECT_DATA
+from tests.fixture_data import CONFIG_YAML, KUBE_RESOURCE_YAML, PROJECT_DATA
 from valohai_cli.commands.execution.run import run
 from valohai_cli.ctx import get_project
 from valohai_cli.models.project import Project
@@ -13,6 +13,15 @@ adhoc_mark = pytest.mark.parametrize('adhoc', (False, True), ids=('regular', 'ad
 @pytest.fixture(params=['regular', 'adhoc'], ids=('regular', 'adhoc'))
 def run_test_setup(request, logged_in_and_linked, monkeypatch):
     return RunTestSetup(monkeypatch=monkeypatch, adhoc=(request.param == 'adhoc'))
+
+
+@pytest.fixture(params=['regular', 'adhoc'], ids=('regular', 'adhoc'))
+def run_test_setup_kube(request, logged_in_and_linked, monkeypatch):
+    return RunTestSetup(
+        monkeypatch=monkeypatch,
+        adhoc=(request.param == 'adhoc'),
+        config_yaml=KUBE_RESOURCE_YAML
+    )
 
 
 @pytest.fixture()
@@ -252,3 +261,133 @@ def test_remote(run_test_setup, tmpdir):
 def test_remote_both_args(run_test_setup):
     run_test_setup.args.append('--debug-port=8101')
     assert "Both or neither" in run_test_setup.run(catch_exceptions=False, verify_adhoc=False)
+
+
+def test_kube_options(run_test_setup):
+    run_test_setup.args.append("--k8s-cpu-min=1")
+    run_test_setup.args.append("--k8s-memory-min=2")
+    run_test_setup.args.append("--k8s-cpu-max=3")
+    run_test_setup.args.append("--k8s-memory-max=4")
+    run_test_setup.args.append("--k8s-device=nvidia.com/gpu=1")
+    run_test_setup.run()
+
+    assert run_test_setup.run_api_mock.last_create_execution_payload["runtime_config"] == {
+        "kubernetes": {
+            'containers': {
+                'workload': {
+                    'resources': {
+                        'requests': {
+                            'cpu': 1.0,
+                            'memory': 2,
+                        },
+                        'limits': {
+                            'cpu': 3,
+                            'memory': 4,
+                            'devices': {
+                                'nvidia.com/gpu': 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_kube_options_partial(run_test_setup):
+    run_test_setup.args.append("--k8s-cpu-min=1")
+    run_test_setup.run()
+
+    assert run_test_setup.run_api_mock.last_create_execution_payload["runtime_config"] == {
+        "kubernetes": {
+            'containers': {
+                'workload': {
+                    'resources': {
+                        'requests': {
+                            'cpu': 1.0,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_kube_options_from_step(run_test_setup_kube):
+    run_test_setup_kube.run()
+
+    assert run_test_setup_kube.run_api_mock.last_create_execution_payload["runtime_config"] == {
+        "kubernetes": {
+            'containers': {
+                'workload': {
+                    'resources': {
+                        'requests': {
+                            'cpu': 1.0,
+                            'memory': 3,
+                        },
+                        'limits': {
+                            'cpu': 2,
+                            'memory': 4,
+                            'devices': {
+                                'nvidia.com/gpu': 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_kube_step_overrides(run_test_setup_kube):
+    run_test_setup_kube.args.append("--k8s-cpu-min=1.5")
+    run_test_setup_kube.args.append("--k8s-cpu-max=3")
+    run_test_setup_kube.args.append("--k8s-device=amd.com/gpu=1")
+    run_test_setup_kube.run()
+
+    assert run_test_setup_kube.run_api_mock.last_create_execution_payload["runtime_config"] == {
+        "kubernetes": {
+            'containers': {
+                'workload': {
+                    'resources': {
+                        'requests': {
+                            'cpu': 1.5,
+                            'memory': 3,
+                        },
+                        'limits': {
+                            'cpu': 3.0,
+                            'memory': 4,
+                            'devices': {
+                                'amd.com/gpu': 1,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_kube_step_override_device_empty(run_test_setup_kube):
+    run_test_setup_kube.args.append("--k8s-device-none")
+    run_test_setup_kube.run()
+
+    assert run_test_setup_kube.run_api_mock.last_create_execution_payload["runtime_config"] == {
+        "kubernetes": {
+            'containers': {
+                'workload': {
+                    'resources': {
+                        'requests': {
+                            'cpu': 1.0,
+                            'memory': 3,
+                        },
+                        'limits': {
+                            'cpu': 2.0,
+                            'memory': 4,
+                            'devices': {}
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/tests/commands/run_test_utils.py
+++ b/tests/commands/run_test_utils.py
@@ -173,14 +173,14 @@ class RunAPIMock(requests_mock.Mocker):
 
 
 class RunTestSetup:
-    def __init__(self, monkeypatch, adhoc, step_name='train'):
+    def __init__(self, monkeypatch, adhoc, step_name='train', config_yaml=CONFIG_YAML):
         self.adhoc = adhoc
         self.project_id = PROJECT_DATA['id']
         self.commit_id = 'f' * 40
         monkeypatch.setattr(git, 'get_current_commit', lambda dir: self.commit_id)
 
         with open(get_project().get_config_filename(), 'w') as yaml_fp:
-            yaml_fp.write(CONFIG_YAML)
+            yaml_fp.write(config_yaml)
 
         # Create an alternative yaml as well (monorepo style)
         with open(get_project().get_config_filename(yaml_path=ALTERNATIVE_YAML), 'w') as yaml_fp:
@@ -198,7 +198,7 @@ class RunTestSetup:
             self._run_api_mock = RunAPIMock(self.project_id, self.commit_id, self.values)
         return self._run_api_mock
 
-    def run(self, *, catch_exceptions=True, verify_adhoc=True) -> str:
+    def run(self, *, catch_exceptions=False, verify_adhoc=True) -> str:
         with self.run_api_mock:
             output = CliRunner().invoke(run, self.args, catch_exceptions=catch_exceptions).output
             if verify_adhoc:

--- a/tests/fixture_data.py
+++ b/tests/fixture_data.py
@@ -566,3 +566,56 @@ def main(config) -> Pipeline:
 
     return pipe
 """
+
+KUBE_RESOURCE_YAML = """
+---
+
+- step:
+    name: Train model
+    image: busybox
+    command: "false"
+    inputs:
+      - name: in1
+        default: http://example.com/
+    parameters:
+      - name: max_steps
+        pass-as: --max_steps={v}
+        description: Number of steps to run the trainer
+        type: integer
+        default: 300
+      - name: learning_rate
+        type: float
+        default: 0.1337
+      - name: enable_mega_boost
+        type: flag
+      - name: multi-parameter
+        default: ["one","two","three"]
+        type: string
+        multiple: separate
+    environment-variables:
+      - name: testenvvar
+        default: 'test'
+    resources:
+      cpu:
+        min: 1.0
+        max: 2
+      memory:
+        min: 3
+        max: 4
+      devices:
+        nvidia.com/gpu: 1
+- endpoint:
+    name: greet
+    image: python:3.9
+    port: 8000
+    server-command: python -m wsgiref.simple_server
+- endpoint:
+    name: predict-digit
+    description: predict digits from image inputs ("file" parameter)
+    image: tensorflow/tensorflow:2.6.0
+    wsgi: predict:predict
+    files:
+      - name: model
+        description: Model output file from TensorFlow
+        path: model.h5
+"""

--- a/valohai_cli/utils/__init__.py
+++ b/valohai_cli/utils/__init__.py
@@ -5,7 +5,7 @@ import re
 import string
 import unicodedata
 import webbrowser
-from typing import Any, Dict, Iterable, Iterator, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, Tuple, Union
 
 import click
 
@@ -132,7 +132,13 @@ def sanitize_option_name(name: str) -> str:
     return re.sub(r'[^-a-z0-9]+', '-', name, flags=re.IGNORECASE).strip('-')
 
 
-def parse_environment_variable_strings(envvar_strings: Iterable[str]) -> Dict[str, str]:
+# Once mypy supports using TypeVars in default arguments, we can make a more specific type for coerce.
+# Mypy issue: https://github.com/python/mypy/issues/3737
+def parse_environment_variable_strings(
+    envvar_strings: Iterable[str],
+    *,
+    coerce: Callable[[str], Any] = str
+) -> Dict[str, Any]:
     """
     Parse a list of environment variable strings into a dict.
     """
@@ -142,7 +148,7 @@ def parse_environment_variable_strings(envvar_strings: Iterable[str]) -> Dict[st
         key = key.strip()
         if not key:
             continue
-        environment_variables[key] = value.strip()
+        environment_variables[key] = coerce(value.strip())
     return environment_variables
 
 


### PR DESCRIPTION
Included in this PR:
===

1. Parse Kubernetes `resource` structure from YAML when using `vh execution run`, if provided.
2. Parse Kubernetes resource claims directly as `vh execution run` command line arguments

`vh pipeline run` does not have execution runtime option override support for now.