### PR TITLE
Give API connection errors a specific exception class

### DIFF
--- a/valohai_cli/exceptions.py
+++ b/valohai_cli/exceptions.py
@@ -108,6 +108,10 @@ class PackageTooLarge(CLIException):
     pass
 
 
+class APIConnectionError(CLIException):
+    pass
+
+
 class NoGitRepo(CLIException):
     color = 'yellow'
 


### PR DESCRIPTION
This will make catching these easier in downstream projects like Jupyhai.