### PR TITLE
Bump `valohai_yaml` to `0.38.0` to support runtime configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "requests-toolbelt>=0.7.1",
     "requests>=2.0.0",
     "valohai-utils>=0.3.0",
-    "valohai-yaml>=0.31.0",
+    "valohai-yaml>=0.38.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
A newer version is required to run tests
(`execution/test_run` fails with too old yaml package).