### PR TITLE
Add command line parameter for runtime config preset

### DIFF
--- a/tests/commands/execution/test_run.py
+++ b/tests/commands/execution/test_run.py
@@ -391,3 +391,18 @@ def test_kube_step_override_device_empty(run_test_setup_kube):
             }
         }
     }
+
+
+def test_kube_runtime_config_preset_argument(run_test_setup_kube):
+    preset_uuid = "yes-this-is-my-preset-uuid"
+    run_test_setup_kube.args.append(f"--k8s-preset={preset_uuid}")
+    run_test_setup_kube.run()
+
+    assert run_test_setup_kube.run_api_mock.last_create_execution_payload["runtime_config_preset"] == preset_uuid
+
+
+def test_kube_no_runtime_config_preset_argument(run_test_setup_kube):
+    """Only add the preset to payload when explicitly specified."""
+    run_test_setup_kube.run()
+
+    assert "runtime_config_preset" not in run_test_setup_kube.run_api_mock.last_create_execution_payload

--- a/valohai_cli/commands/execution/run/dynamic_run_command.py
+++ b/valohai_cli/commands/execution/run/dynamic_run_command.py
@@ -71,7 +71,7 @@ class RunCommand(click.Command):
         :param environment: Environment identifier (slug or UUID)
         :param environment_variables: Mapping of environment variables
         :param tags: Tags to apply
-        :param watch: Whether to chain to `exec watch` afterwards
+        :param watch: Whether to chain to `exec watch` afterward
         :param image: Image override
         :param download_directory: Where to (if somewhere) to download execution outputs (sync mode)
         :param runtime_config: Runtime config dict
@@ -130,7 +130,7 @@ class RunCommand(click.Command):
         help = parameter.description
         is_multiple = parameter.multiple is not None
         if is_multiple:
-            help = "(Multiple) " + (help if help else "")
+            help = "(Multiple) " + (help or "")
         option = click.Option(
             param_decls=list(generate_sanitized_options(parameter.name)),
             required=False,  # This is done later
@@ -143,7 +143,8 @@ class RunCommand(click.Command):
         option.help_group = 'Parameter Options'  # type: ignore[attr-defined]
         return option
 
-    def convert_input_to_option(self, input: Input) -> Option:
+    @staticmethod
+    def convert_input_to_option(input: Input) -> Option:
         """
         Convert an Input into a click Option.
         """
@@ -238,7 +239,7 @@ class RunCommand(click.Command):
             else:
                 options[key] = value
         self._process_parameters(params, parameter_file=options.get('parameter_file'))
-        return (options, params, inputs)
+        return options, params, inputs
 
     def _process_parameters(self, parameters: Dict[str, Any], parameter_file: Optional[str]) -> None:  # noqa: C901
         if parameter_file:

--- a/valohai_cli/commands/execution/run/dynamic_run_command.py
+++ b/valohai_cli/commands/execution/run/dynamic_run_command.py
@@ -58,6 +58,7 @@ class RunCommand(click.Command):
         environment_variables: Optional[Dict[str, str]] = None,
         tags: Optional[Sequence[str]] = None,
         runtime_config: Optional[dict] = None,
+        runtime_config_preset: Optional[str] = None,
     ) -> None:
 
         """
@@ -74,6 +75,7 @@ class RunCommand(click.Command):
         :param image: Image override
         :param download_directory: Where to (if somewhere) to download execution outputs (sync mode)
         :param runtime_config: Runtime config dict
+        :param runtime_config_preset: Runtime config preset identifier (UUID)
         """
         assert isinstance(step, Step)
         self.project = project
@@ -88,6 +90,7 @@ class RunCommand(click.Command):
         self.environment_variables = dict(environment_variables or {})
         self.tags = list(tags or [])
         self.runtime_config = dict(runtime_config or {})
+        self.runtime_config_preset = runtime_config_preset
         super().__init__(
             name=sanitize_option_name(step.name.lower()),
             callback=self.execute,
@@ -158,7 +161,7 @@ class RunCommand(click.Command):
         option.help_group = 'Input Options'  # type: ignore[attr-defined]
         return option
 
-    def execute(self, **kwargs: Any) -> None:
+    def execute(self, **kwargs: Any) -> None:  # noqa: C901
         """
         Execute the creation of the execution. (Heh.)
 
@@ -188,6 +191,8 @@ class RunCommand(click.Command):
             payload['tags'] = self.tags
         if self.runtime_config:
             payload['runtime_config'] = self.runtime_config
+        if self.runtime_config_preset:
+            payload['runtime_config_preset'] = self.runtime_config_preset
 
         resp = request(
             method='post',

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -48,6 +48,7 @@ EMPTY_DICT_PLACEHOLDER = object()
 @click.option('--k8s-memory-max', help="Kubernetes only. Memory resource request. Unit is binary megabytes (Mi)", type=int)
 @click.option('--k8s-device', 'k8s_devices', multiple=True, help="Kubernetes only. Custom device claim. Format: NAME=VALUE. May be repeated for multiple limits.")
 @click.option('--k8s-device-none', is_flag=True, help="Kubernetes only. Request no device claims, not even if there is a default")
+@click.option('--k8s-preset', default=None, help="Kubernetes only. Custom runtime config preset UUID")
 @click.argument('args', nargs=-1, type=click.UNPROCESSED, metavar='STEP-OPTIONS...')
 @click.pass_context
 def run(
@@ -76,6 +77,7 @@ def run(
     k8s_memory_max: Optional[int],
     k8s_devices: List[str],
     k8s_device_none: bool,
+    k8s_preset: Optional[str],
 ) -> Any:
     """
     Start an execution of a step.
@@ -178,6 +180,7 @@ def run(
         environment_variables=parse_environment_variable_strings(environment_variables),
         tags=tags,
         runtime_config=runtime_config,
+        runtime_config_preset=k8s_preset,
     )
     with rc.make_context(rc.name, list(args), parent=ctx) as child_ctx:
         return rc.invoke(child_ctx)


### PR DESCRIPTION
Resolves #303 

Allow setting a preset ID with the `--k8s-preset` command line option.

Note: preset slug support will be automatic once that has been added to the API – no functional changes required (though the help text should be updated).

_Note:_ The first commit contains all the functional changes in this PR – the rest are just refactoring and tidying up the code a bit. Especially the last one is things that are more a matter of taste (and can be reverted easily).