### PR TITLE
Use `uv` for dependencies if installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,22 @@
+UV := $(shell command -v uv)
+ifdef UV
+    PIP_INSTALL = uv pip install
+else
+    PIP_INSTALL = pip install
+endif
+
 .PHONY: default
 default:
 	@echo "check README for usage"
 
 .PHONY: dev
 dev:
+ifndef UV
 	pip install -U pip
-	pip install -r requirements-test.txt
-	pip install pre-commit
-	pip install -e .
+endif
+	$(PIP_INSTALL) -r requirements-test.txt
+	$(PIP_INSTALL) pre-commit
+	$(PIP_INSTALL) -e .
 	pre-commit install
 
 .PHONY: lint


### PR DESCRIPTION
Install and update dependencies with `uv`, fall back to regular `pip`.
Both work if virtual environment was created with `venv` or `virtualenv`.

Add requirement for an active virtual environment before installing packages to prevent accidentally updating a global Python installation.