### PR TITLE
Smoother token login flow

### DIFF
--- a/valohai_cli/messages.py
+++ b/valohai_cli/messages.py
@@ -90,7 +90,7 @@ def banner(message: str, banner_char: str = '=', banner_style: Optional[dict] = 
     if banner_style is None:
         banner_style = DEFAULT_BANNER_STYLE
 
-    longest_line_len = max(len(line) for line in message.splitlines())
+    longest_line_len = max(len(line) for line in click.unstyle(message).splitlines())
 
     banner_line = banner_char * longest_line_len
     click.secho(banner_line, **banner_style)


### PR DESCRIPTION
Instead of telling the user to run a command to log in with the token they generate, we ask for it interactively.

Fixes #307.

In lieu of a screenshot...
```
$ vh login --host https://valohai.local/

If you don't yet have an account, please create one at https://valohai.local/ first.

https://valohai.local/ - Username: 2faman
2faman on https://valohai.local/ - Password: [...]
Retrieving API token from https://valohai.local/...
======================================================================================
Oops!
The error code "has_2fa" indicates username + password authentication is not possible.
Use a login token instead:
 1. Log in on https://valohai.local/
 2. Visit https://valohai.local/auth/tokens/ to generate an authentication token
 3. Once you have an authentication token, paste it below and we'll try it out.
======================================================================================
Enter generated token: [...]
Verifying API token on https://valohai.local/...
😄  Success! Logged in. Hey 2faman!
```