### PR TITLE
Support list parameters for pipelines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "requests-toolbelt>=0.7.1",
     "requests>=2.0.0",
     "valohai-utils>=0.3.0",
-    "valohai-yaml>=0.38.0",
+    "valohai-yaml>=0.40.0",
 ]
 
 [project.scripts]

--- a/tests/commands/run_test_utils.py
+++ b/tests/commands/run_test_utils.py
@@ -31,6 +31,7 @@ class RunAPIMock(requests_mock.Mocker):
         deployment_id=666,
         additional_payload_values=None,
         deployment_version_name='220801.0',
+        num_parameters=None,
     ):
         super().__init__()
         self.last_create_execution_payload = None
@@ -40,6 +41,7 @@ class RunAPIMock(requests_mock.Mocker):
         self.deployment_id = deployment_id
         self.deployment_version_name = deployment_version_name
         self.additional_payload_values = (additional_payload_values or {})
+        self.num_parameters = num_parameters
         self.get(
             f'https://app.valohai.com/api/v0/projects/{project_id}/',
             json=self.handle_project,
@@ -154,7 +156,7 @@ class RunAPIMock(requests_mock.Mocker):
         assert len(body_json['edges']) == 5
         assert len(body_json['nodes']) == 3
         if "parameters" in body_json:
-            assert len(body_json['parameters']) == 1
+            assert len(body_json['parameters']) == self.num_parameters
         context.status_code = 201
         self.last_create_pipeline_payload = body_json
         return PIPELINE_DATA.copy()

--- a/tests/fixture_data.py
+++ b/tests/fixture_data.py
@@ -305,6 +305,14 @@ PIPELINE_YAML = CONFIG_YAML + """
     name: Preprocess dataset (MNIST)
     image: tensorflow/tensorflow:1.13.1-gpu-py3
     command: python preprocess.py
+    parameters:
+      - name: sources
+        type: string
+        multiple: separate
+        multiple-separator: '-'
+        default:
+        - port
+        - railyard
     inputs:
       - name: training-set-images
         default: https://valohaidemo.blob.core.windows.net/mnist/train-images-idx3-ubyte.gz
@@ -440,6 +448,10 @@ PIPELINE_YAML = CONFIG_YAML + """
         default: 1000
         targets:
             - Train model (MNIST).parameters.max_steps
+      - name: sources
+        default: [airport]
+        targets:
+            - preprocess.parameters.sources
 """
 
 YAML_WITH_EXTRACT_TRAIN_EVAL = """

--- a/tests/test_remote_project.py
+++ b/tests/test_remote_project.py
@@ -16,7 +16,7 @@ def remote_project_setup(request, monkeypatch, tmpdir):
     project_id = PROJECT_DATA['id']
     request.addfinalizer(lambda: settings.reset())
     monkeypatch.chdir(tmpdir)
-    with RunAPIMock(project_id, 'f' * 40, {}):
+    with RunAPIMock(project_id, 'f' * 40, {}, num_parameters=2):
         configure_token_login(None, test_token)
         configure_project_override(project_id=project_id, mode=None)
         assert isinstance(settings.override_project, RemoteProject)


### PR DESCRIPTION
Extends pipeline command line parameter parsing to allow overriding the default pipeline parameters with a list parameter

Upgrades `valohai-yaml` dependency to 0.40.0 containing list-type pipeline parameter support as well as override support in PipelineConverter which we will pass any command line overrides to