### PR TITLE
Add SSH command for executions 

### DIFF
--- a/tests/commands/execution/test_ssh.py
+++ b/tests/commands/execution/test_ssh.py
@@ -1,0 +1,80 @@
+import shutil
+import subprocess
+import time
+
+from tests.commands.execution.utils import get_execution_data_mock, no_sleep
+from tests.fixture_data import EXECUTION_DATA, STATUS_EVENT_RESPONSE_DATA
+from valohai_cli.commands.execution.ssh import ssh
+
+
+def test_ssh_in_completed_execution(runner, logged_in_and_linked, monkeypatch):
+    with get_execution_data_mock():
+        counter = EXECUTION_DATA["counter"]
+        result = runner.invoke(ssh, [str(counter)], catch_exceptions=False)
+        assert f"Error: Execution #{counter} is complete. Cannot SSH into it.\n" in result.output
+        assert result.exit_code == 1
+
+
+def test_ssh_in_queued_execution(runner, logged_in_and_linked, monkeypatch):
+    counter = EXECUTION_DATA["counter"]
+    monkeypatch.setitem(EXECUTION_DATA, "status", "queued")
+    monkeypatch.setattr(time, "sleep", no_sleep)
+    with get_execution_data_mock():
+        result = runner.invoke(ssh, [str(counter)], catch_exceptions=False)
+        assert f"Execution #{counter} is queued. Waiting for it to start...\n" in result.output
+        assert result.exit_code == 1
+
+
+def test_ssh_with_no_ssh_details_present(runner, logged_in_and_linked, monkeypatch):
+    counter = EXECUTION_DATA["counter"]
+    monkeypatch.setitem(EXECUTION_DATA, "status", "started")
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    with get_execution_data_mock() as m:
+        m.get(
+            f"https://app.valohai.com/api/v0/executions/{EXECUTION_DATA['id']}/status-events/",
+            json={"status_events": []},
+        )
+        result = runner.invoke(ssh, [str(counter)], catch_exceptions=False)
+        output = result.output
+        assert "1/5 Retrying: No SSH details found...\n" in output
+        assert "2/5 Retrying: No SSH details found...\n" in output
+        assert "3/5 Retrying: No SSH details found...\n" in output
+        assert "4/5 Retrying: No SSH details found...\n" in output
+        assert "5/5 Retrying: No SSH details found...\n" in output
+
+    assert result.exit_code == 1
+
+
+def test_ssh(runner, logged_in_and_linked, monkeypatch, tmp_path):
+    counter = EXECUTION_DATA["counter"]
+    monkeypatch.setitem(EXECUTION_DATA, "status", "started")
+
+    def mock_prompt():
+        return tmp_path
+
+    monkeypatch.setattr(
+        "valohai_cli.commands.execution.ssh.select_private_key_from_possible_directories",
+        mock_prompt,
+    )
+
+    with get_execution_data_mock() as m:
+        m.get(
+            f"https://app.valohai.com/api/v0/executions/{EXECUTION_DATA['id']}/status-events/",
+            json=STATUS_EVENT_RESPONSE_DATA,
+        )
+        result = runner.invoke(ssh, [str(counter)], catch_exceptions=False)
+        output = result.output
+        assert "SSH address is 127.0.0.1:2222" in output
+
+        def mock_subprocess_run(*args, **kwargs):
+            print(args[0])
+            return subprocess.CompletedProcess(args=args, returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", mock_subprocess_run)
+
+        result = result.runner.invoke(ssh, [str(counter)], input="1", catch_exceptions=False)
+        assert (
+            f"['{shutil.which('ssh')}', '-i', PosixPath('{tmp_path}'), 'root@127.0.0.1', '-p', '2222', '-t', '/bin/bash']"
+            in result.output
+        )
+        assert result.exit_code == 0

--- a/tests/commands/execution/test_watch.py
+++ b/tests/commands/execution/test_watch.py
@@ -1,12 +1,8 @@
 import time
 
-from tests.commands.execution.utils import get_execution_data_mock
+from tests.commands.execution.utils import get_execution_data_mock, no_sleep
 from tests.fixture_data import EXECUTION_DATA, PROJECT_DATA
 from valohai_cli.commands.execution.watch import watch
-
-
-def no_sleep(t):
-    raise KeyboardInterrupt("no... sleep... til... Brooklyn!")
 
 
 def test_execution_watch(runner, logged_in_and_linked, monkeypatch):

--- a/tests/commands/execution/utils.py
+++ b/tests/commands/execution/utils.py
@@ -36,3 +36,7 @@ def get_execution_data_mock():
     m.delete(execution_by_counter_url, json={"ok": True})
     m.post(re.compile("^https://app.valohai.com/api/v0/data/(.+?)/purge/$"), json={"ok": True})
     return m
+
+
+def no_sleep(t):
+    raise KeyboardInterrupt("no... sleep... til... Brooklyn!")

--- a/tests/fixture_data.py
+++ b/tests/fixture_data.py
@@ -330,7 +330,6 @@ CONFIG_YAML = """
         path: model.h5
 """
 
-
 PIPELINE_YAML = (
     CONFIG_YAML
     + """
@@ -665,3 +664,19 @@ KUBE_RESOURCE_YAML = """
         description: Model output file from TensorFlow
         path: model.h5
 """
+
+STATUS_EVENT_RESPONSE_DATA = {
+    "total": 2,
+    "status_events": [
+        {
+            "stream": "status",
+            "message": '::ssh::{"port": 2222, "address": "127.0.0.1"}',
+            "time": "2024-09-04T12:16:20.722000",
+        },
+        {
+            "stream": "status",
+            "message": "   $ ssh -i <path-to-private-key> 127.0.0.1 -p 2222 -t /bin/bash",
+            "time": "2024-09-04T12:16:20.723000",
+        },
+    ],
+}

--- a/valohai_cli/commands/execution/ssh.py
+++ b/valohai_cli/commands/execution/ssh.py
@@ -1,0 +1,46 @@
+import click
+
+from valohai_cli.exceptions import CLIException
+from valohai_cli.utils.cli_utils import counter_argument
+from valohai_cli.utils.ssh import (
+    get_ssh_details_with_retry,
+    make_ssh_connection,
+    select_private_key_from_possible_directories,
+)
+
+
+@click.command()
+@counter_argument
+@click.option(
+    "--private-key-file",
+    default=None,
+    type=click.Path(file_okay=True, exists=True),
+    help="Private SSH key to use for the connection.",
+)
+@click.option(
+    "--address",
+    default=None,
+    help='Address of the container in "ip:port" format. If not provided, '
+    "the address from the execution will be used.",
+)
+def ssh(counter: int, private_key_file: str, address: str) -> None:
+    """
+    Make SSH Connection to the execution container.
+    """
+    if address:
+        try:
+            ip_address, _, port_str = address.partition(":")
+            if not ip_address or not port_str:
+                raise CLIException("Address must be in 'ip:port' format.")
+            port = int(port_str)
+            if port <= 1023:
+                raise CLIException("Port must be above 1023")
+        except ValueError as e:
+            raise CLIException(f"Invalid address format: {e}")
+    else:
+        ip_address, port = get_ssh_details_with_retry(counter)
+
+    click.echo(f"SSH address is {ip_address}:{port}")
+    if not private_key_file:
+        private_key_file = select_private_key_from_possible_directories()
+    make_ssh_connection(ip_address, port, private_key_file)

--- a/valohai_cli/settings/paths.py
+++ b/valohai_cli/settings/paths.py
@@ -12,6 +12,10 @@ def get_settings_root_path() -> str:  # pragma: no cover
 
 
 def get_settings_file_name(name: str) -> str:
+    """
+    Get the path to a settings file in the user's configuration directory.
+    name can be empty string to get the directory itself.
+    """
     path = os.environ.get("VALOHAI_CONFIG_DIR")
     if path:
         if not os.path.isdir(path):

--- a/valohai_cli/utils/ssh.py
+++ b/valohai_cli/utils/ssh.py
@@ -1,0 +1,144 @@
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from itertools import count
+from typing import Generator, Iterable, Iterator, Optional, Tuple
+
+import click
+
+from valohai_cli.api import request
+from valohai_cli.ctx import get_project
+from valohai_cli.exceptions import CLIException
+from valohai_cli.settings import get_settings_file_name
+from valohai_cli.utils import call_with_retry
+from valohai_cli.utils.cli_utils import prompt_from_list
+
+
+@dataclass(frozen=True)
+class Keypair:
+    public_path: pathlib.Path
+    private_path: pathlib.Path
+
+
+def make_ssh_connection(address: str, port: int, private_key_path: str) -> None:
+    ssh_path = shutil.which("ssh")
+    if ssh_path is None:
+        raise FileNotFoundError(
+            "SSH command not found. Ensure SSH is installed and available in your PATH.",
+        )
+    ssh_command = [
+        ssh_path,
+        "-i",
+        private_key_path,
+        f"root@{address}",
+        "-p",
+        str(port),
+        "-t",
+        "/bin/bash",
+    ]
+    subprocess.run(ssh_command)
+
+
+def find_ssh_details(events: Iterable) -> Optional[Tuple[str, int]]:
+    prefix = "::ssh::"
+    for event in events:
+        if event["message"].startswith(prefix):
+            data = json.loads(event["message"][len(prefix) :])
+            return data["address"], int(data["port"])
+    return None
+
+
+def get_ssh_key_pairs_from_dir(dir: str) -> Iterator[Keypair]:
+    folder_path = pathlib.Path(dir)
+    for pth in folder_path.glob("*.pub"):
+        if not pth.is_file():
+            continue
+        try:
+            with pth.open("rb") as f:
+                first_line = f.readline().strip()
+                if first_line.startswith((b"ssh-rsa", b"ecdsa-sha2-", b"ssh-ed25519")):
+                    private_key_paths = [pth.with_suffix(""), pth.with_suffix(".pem")]
+                    for private_key_path in private_key_paths:
+                        if private_key_path.is_file():
+                            yield Keypair(public_path=pth, private_path=private_key_path)
+                            break
+        except OSError:  # e.g. unreadable key
+            pass
+
+
+def select_private_key_from_possible_directories() -> str:
+    default_ssh_dir = os.path.expanduser("~/.ssh")
+    cli_config_dir = get_settings_file_name("")
+    all_keypairs: list[Keypair] = []
+    all_dirs = [cli_config_dir, default_ssh_dir]
+    for dir in all_dirs:
+        if not os.path.isdir(dir):
+            continue
+        all_keypairs.extend(get_ssh_key_pairs_from_dir(dir))
+
+    if not all_keypairs:
+        raise click.UsageError(
+            f"No SSH key pairs found in {', '.join(all_dirs)}. Please try to generate new SSH key pair",
+        )
+
+    keypair_options = [
+        {
+            "name": keypair.private_path,
+            "description": f"Public: {keypair.public_path}",
+        }
+        for keypair in all_keypairs
+    ]
+
+    selected_key = prompt_from_list(prompt="Select the SSH key pair you want to use", options=keypair_options)
+    return str(selected_key["name"])
+
+
+def fetch_status_events(execution: dict, first_n: Optional[int] = None) -> Generator:
+    params = {}
+    if first_n is not None:
+        params["limit"] = first_n
+    events_response = request("get", f"{execution['url']}status-events/", params=params).json()
+    yield from events_response.get("status_events", [])
+
+
+def get_ssh_details_from_execution(execution: dict) -> Tuple[str, int]:
+    events_response = fetch_status_events(execution, first_n=100)
+    ssh_details = find_ssh_details(events_response)
+    if not ssh_details:
+        raise click.UsageError("No SSH details found")
+    return ssh_details
+
+
+def get_ssh_details_with_retry(
+    counter: int,
+) -> Tuple[str, int]:
+    """
+    Fetch SSH details for a given counter, retrying until the execution has started.
+
+    :param counter: The execution counter.
+    :return: A tuple of (IP address, port) for the SSH connection.
+    """
+    project = get_project(require=True)
+    assert project
+    for attempt in count():
+        execution = project.get_execution_from_counter(
+            counter=counter,
+            params={"exclude": "metadata, events"},
+        )
+        if execution["status"] in ("queued", "created"):
+            if attempt % 3 == 0:  # print on first attempt and thereafter every 3 attempts
+                click.echo(f"Execution #{counter} is {execution['status']}. Waiting for it to start...")
+            time.sleep(5)
+            continue
+        if execution["status"] != "started":
+            raise CLIException(f"Execution #{counter} is {execution['status']}. Cannot SSH into it.")
+        break
+    return call_with_retry(
+        func=lambda: get_ssh_details_from_execution(execution=execution),
+        retries=5,
+        delay_range=(1, 7),
+    )


### PR DESCRIPTION
Resolves #312 
User will be able to remotely debug the execution 
1. He can either provide address:port & private key by himself or run the command for auto collection of the details
2. If the key is generated in CLI while starting the execution it can be found by command and prompted to user as option 
3. But if the execution is started by UI or key is generated somewhere user HAS to provide that key as command argument `--private-key-file `


[ssh.webm](https://github.com/user-attachments/assets/ec4c3d48-5bb8-4f48-9a88-a2ff7f9586bf)
