### PR TITLE
Upgrade lint and CI tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
           cache: "pip"
@@ -34,30 +35,30 @@ jobs:
           EMAIL: foo@example.com
           GIT_AUTHOR_NAME: Foo Bar
           GIT_COMMITTER_NAME: Foo Bar
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v4
   Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: pyproject.toml
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
   Build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "pip"
           cache-dependency-path: "**/requirements*txt"
       - run: pip install build
       - run: python -m build
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.3
+    rev: v0.6.4
     hooks:
       - id: ruff
         args:
@@ -9,7 +9,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.11.2
     hooks:
       - id: mypy
         additional_dependencies:

--- a/scripts/ensure_click_help.py
+++ b/scripts/ensure_click_help.py
@@ -38,7 +38,7 @@ def process_file(filename: str) -> List[str]:
     messages = []
 
     def add_message(node: ast.AST, message: str) -> None:
-        messages.append(f"{filename}:{node.lineno}: {message}")
+        messages.append(f"{filename}:{node.lineno}: {message}")  # type: ignore[attr-defined]
 
     EnsureClickHelpWalker(add_message=add_message).visit(tree)
     return messages

--- a/tests/test_cli_descriptions.py
+++ b/tests/test_cli_descriptions.py
@@ -36,7 +36,7 @@ def test_all_commands_have_help(runner, monkeypatch):
     exceptions = list(find_commands_with_no_help(root_command))
 
     if exceptions:
-        raise ExceptionGroup(
+        raise ExceptionGroup(  # noqa: F821
             f"{len(exceptions)} commands have no help text",
             exceptions,
         )


### PR DESCRIPTION
`build` would fail due to an outdated upload action. Might as well upgrade everything else.