### PR TITLE
🩹 Pass time-limit YAML setting to execution

### DIFF
--- a/valohai_cli/commands/execution/run/dynamic_run_command.py
+++ b/valohai_cli/commands/execution/run/dynamic_run_command.py
@@ -62,6 +62,7 @@ class RunCommand(click.Command):
         runtime_config_preset: Optional[str] = None,
         ssh: bool = False,
         priority: Optional[int] = None,
+        time_limit: Optional[str] = None,
     ) -> None:
         """
         Initialize the dynamic run command.
@@ -96,6 +97,7 @@ class RunCommand(click.Command):
         self.runtime_config_preset = runtime_config_preset
         self.ssh = ssh
         self.priority = priority
+        self.time_limit = time_limit
         super().__init__(
             name=sanitize_option_name(step.name.lower()),
             callback=self.execute,
@@ -236,6 +238,7 @@ class RunCommand(click.Command):
         payload.update(self._optional_item("runtime_config"))
         payload.update(self._optional_item("runtime_config_preset"))
         payload.update(self._optional_item("priority"))
+        payload.update(self._optional_item("time_limit"))
 
         return payload
 

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -258,6 +258,8 @@ def run(
     if autorestart:
         runtime_config["autorestart"] = autorestart
 
+    time_limit = step.time_limit.total_seconds() if step.time_limit else None
+
     if k8s_devices and k8s_device_none:
         raise click.UsageError(
             "--k8s-device=(...) and --k8s-device-none cannot be used together. "
@@ -309,6 +311,7 @@ def run(
         runtime_config_preset=k8s_preset,
         ssh=ssh,
         priority=priority,
+        time_limit=time_limit,
     )
     with rc.make_context(rc.name, list(args), parent=ctx) as child_ctx:
         return rc.invoke(child_ctx)


### PR DESCRIPTION
Resolves [valohai/roi#8352
](https://github.com/valohai/roi/issues/8352) (`time_limit` not passed to execution via CLI)

The `time-limit` setting is parsed and included in the execution parameters if it is set
(0 = no time limit, so it is not included in the params).
