### PR TITLE
Allow overriding node environments when starting a pipeline

### DIFF
--- a/tests/commands/pipeline/test_run.py
+++ b/tests/commands/pipeline/test_run.py
@@ -3,6 +3,7 @@ from pytest import raises
 
 from tests.commands.run_test_utils import RunAPIMock
 from tests.fixture_data import PIPELINE_YAML, PROJECT_DATA
+from tests.utils import write_yaml_config
 from valohai_cli.commands.pipeline.run import run
 from valohai_cli.commands.pipeline.run.utils import match_pipeline
 from valohai_cli.ctx import get_project
@@ -62,11 +63,8 @@ def test_match_pipeline_ambiguous(runner, logged_in_and_linked):
         match_pipeline(config, "Train")
 
 
-def add_valid_pipeline_yaml(yaml_path=None):
-    project = get_project()
-    config_filename = project.get_config_filename(yaml_path=yaml_path)
-    with open(config_filename, "w") as yaml_fp:
-        yaml_fp.write(PIPELINE_YAML)
+def add_valid_pipeline_yaml(yaml_path=None) -> None:
+    write_yaml_config(PIPELINE_YAML, yaml_path=yaml_path)
 
 
 def test_pipeline_parameters_overriding(runner, logged_in_and_linked):

--- a/tests/commands/run_test_utils.py
+++ b/tests/commands/run_test_utils.py
@@ -30,9 +30,14 @@ class RunAPIMock(requests_mock.Mocker):
         deployment_id=666,
         additional_payload_values=None,
         deployment_version_name="220801.0",
-        num_parameters=None,
+        num_parameters=0,
+        expected_node_count=3,
+        expected_edge_count=5,
     ):
         super().__init__()
+        self.expected_node_count = expected_node_count
+        self.expected_edge_count = expected_edge_count
+        self.num_parameters = num_parameters
         self.last_create_execution_payload = None
         self.last_create_pipeline_payload = None
         self.project_id = project_id
@@ -40,7 +45,6 @@ class RunAPIMock(requests_mock.Mocker):
         self.deployment_id = deployment_id
         self.deployment_version_name = deployment_version_name
         self.additional_payload_values = additional_payload_values or {}
-        self.num_parameters = num_parameters
         self.get(
             f"https://app.valohai.com/api/v0/projects/{project_id}/",
             json=self.handle_project,
@@ -152,8 +156,8 @@ class RunAPIMock(requests_mock.Mocker):
     def handle_create_pipeline(self, request, context):
         body_json = json.loads(request.body.decode("utf-8"))
         assert body_json["project"] == self.project_id
-        assert len(body_json["edges"]) == 5
-        assert len(body_json["nodes"]) == 3
+        assert len(body_json["edges"]) == self.expected_edge_count
+        assert len(body_json["nodes"]) == self.expected_node_count
         if "parameters" in body_json:
             assert len(body_json["parameters"]) == self.num_parameters
         context.status_code = 201

--- a/tests/fixture_data.py
+++ b/tests/fixture_data.py
@@ -680,3 +680,42 @@ STATUS_EVENT_RESPONSE_DATA = {
         },
     ],
 }
+
+PIPELINE_WITH_TASK_EXAMPLE = """
+- step:
+    name: preprocess
+    image: python:3.7
+    command:
+      - python ./preprocess.py
+- step:
+    name: train
+    image: python:3.7
+    command:
+      - pip install valohai-utils
+      - python ./train.py {parameters}
+    parameters:
+      - name: id
+        type: string
+- pipeline:
+    name: dynamic-task
+    nodes:
+      - name: preprocess
+        step: preprocess
+        type: execution
+      - name: train-with-errors
+        step: train
+        type: task
+        on-error: "continue"
+      - name: train-optional
+        step: train
+        type: task
+        on-error: "stop-next"
+      - name: train-critical
+        step: train
+        type: task
+        on-error: "stop-all"
+    edges:
+      - [preprocess.metadata.storeids, train-critical.parameter.id]
+      - [preprocess.metadata.storeids, train-optional.parameter.id]
+      - [preprocess.metadata.storeids, train-with-errors.parameter.id]
+"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+from valohai_cli.ctx import get_project
+
 
 def get_project_list_data(project_names):
     return {
@@ -38,3 +40,10 @@ def make_call_stub(retval=None):
 
     call_stub.calls = calls
     return call_stub
+
+
+def write_yaml_config(yaml_content: str, yaml_path=None) -> None:
+    project = get_project()
+    config_filename = project.get_config_filename(yaml_path=yaml_path)
+    with open(config_filename, "w") as yaml_fp:
+        yaml_fp.write(yaml_content)


### PR DESCRIPTION
Allow setting `--environment` when creating pipelines; it adds/replaces the `environment` value in each node's `template`.