### PR TITLE
Handle 'Content-Disposition: attachment' when downloading outputs

### DIFF
--- a/valohai_cli/api.py
+++ b/valohai_cli/api.py
@@ -18,6 +18,15 @@ from valohai_cli.settings import settings
 from valohai_cli.utils import force_text
 
 
+def get_user_agent() -> str:
+    uname = ";".join(platform.uname())
+    py_version = f"{platform.python_implementation()} {platform.python_version()}"
+    user_agent = f"valohai-cli/{VERSION} on {py_version} ({uname})"
+    if settings.api_user_agent_prefix:
+        user_agent = f"{settings.api_user_agent_prefix} {user_agent}"
+    return user_agent
+
+
 class TokenAuth(AuthBase):
     def __init__(self, netloc: str, token: Optional[str]) -> None:
         super().__init__()
@@ -55,12 +64,8 @@ class APISession(requests.Session):
         self.headers["Accept"] = "application/json"
 
     def get_user_agent(self) -> str:
-        uname = ";".join(platform.uname())
-        py_version = f"{platform.python_implementation()} {platform.python_version()}"
-        user_agent = f"valohai-cli/{VERSION} on {py_version} ({uname})"
-        if settings.api_user_agent_prefix:
-            user_agent = f"{settings.api_user_agent_prefix} {user_agent}"
-        return user_agent
+        # Overridable by subclasses (even remotely implemented).
+        return get_user_agent()
 
     def prepare_request(self, request: Request) -> PreparedRequest:
         request.headers.setdefault("User-Agent", self.get_user_agent())

--- a/valohai_cli/commands/execution/outputs.py
+++ b/valohai_cli/commands/execution/outputs.py
@@ -150,6 +150,9 @@ def filter_outputs(
 
 
 def download_outputs(outputs: List[dict], output_path: str, show_success_message: bool = True) -> None:
+    if not outputs:
+        info("No outputs to download.")
+        return
     total_size = sum(o["size"] for o in outputs)
     num_width = len(str(len(outputs)))  # How many digits required to print the number of outputs
     start_time = time.time()

--- a/valohai_cli/commands/execution/outputs.py
+++ b/valohai_cli/commands/execution/outputs.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import click
 import requests
 
-from valohai_cli.api import request
+from valohai_cli.api import get_user_agent, request
 from valohai_cli.consts import complete_execution_statuses
 from valohai_cli.ctx import get_project
 from valohai_cli.messages import info, success, warn
@@ -158,6 +158,7 @@ def download_outputs(outputs: List[dict], output_path: str, show_success_message
         show_pos=True,
         item_show_func=str,
     ) as prog, requests.Session() as dl_sess:
+        dl_sess.headers["User-Agent"] = f"{get_user_agent()} (downloader)"
         for i, output in enumerate(outputs, 1):
             name = output["name"]
             url = request(


### PR DESCRIPTION
This is required for certain private server configurations.