### PR TITLE
Pin Click to latest version that does not break tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Valohai", email = "hait@valohai.com" },
 ]
 dependencies = [
-    "click>=8.0",
+    "click>=8.0,<8.2",  # 8.2 produces extra warnings about Git directory that break expected output in tests
     "gitignorant>=0.4.0",
     "requests-toolbelt>=0.7.1",
     "requests>=2.0.0",


### PR DESCRIPTION
Click v8.2 introduces some changes that break tests, especially where git operations are monkeypatched: it produces the following extra warning output:
```
Warning: The directory is not a Git repository. 
Would you like to just run using the latest commit known by Valohai?
Use latest commit? [Y/n]:Aborted!
```

Naturally, this breaks the tests that check the output for expected test.

Temporarily fixed by pinning `click` to a version below `8.2`.

---

Also update `setup-uv` to `v6` while at it (unrelated, but left there since it was already there due to earlier testing).