### PR TITLE
✨ Make the `--environment` parameter optional

### DIFF
--- a/tests/commands/notebook/test_notebook_execution_run.py
+++ b/tests/commands/notebook/test_notebook_execution_run.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.fixture_data import NOTEBOOK_EXECUTION_DATA
 from valohai_cli.commands.notebook.run import run
+from valohai_cli.consts import API_DEFAULT_ENVIRONMENT_SLUG
 
 
 @pytest.mark.parametrize("with_envvars", [True, False])
@@ -19,3 +20,16 @@ def test_run_success(runner, logged_in_and_linked, using_default_run_api_mock, w
     assert payload["image"] == "python:3.14"
     if with_envvars:
         assert payload["environment_variables"] == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_default_environment(runner, logged_in_and_linked, using_default_run_api_mock):
+    """Test that PROJECT_DEFAULT is used if environment not set."""
+    args = ["--image", "python:3.14"]
+
+    res = runner.invoke(run, args)
+    assert res.exit_code == 0
+
+    payload = using_default_run_api_mock.last_create_notebook_execution_payload
+    assert payload["environment"] == API_DEFAULT_ENVIRONMENT_SLUG, (
+        f"Should default to {API_DEFAULT_ENVIRONMENT_SLUG} environment"
+    )

--- a/valohai_cli/commands/notebook/run/run.py
+++ b/valohai_cli/commands/notebook/run/run.py
@@ -5,6 +5,7 @@ from typing import Any, Sequence
 import click
 
 from valohai_cli.api import request
+from valohai_cli.consts import API_DEFAULT_ENVIRONMENT_SLUG
 from valohai_cli.ctx import get_project
 from valohai_cli.messages import success
 from valohai_cli.utils import parse_environment_variable_strings
@@ -14,8 +15,8 @@ from valohai_cli.utils import parse_environment_variable_strings
 @click.option(
     "--environment",
     "-e",
-    help="Environment UUID or slug to run the execution in.",
-    required=True,
+    help="Environment UUID or slug to run the execution in (default = project default environment).",
+    required=False,
 )
 @click.option(
     "--image",
@@ -43,6 +44,9 @@ def run(
     """
     project = get_project(require=True)
     assert project
+
+    if not environment:
+        environment = API_DEFAULT_ENVIRONMENT_SLUG
 
     start_execution(
         environment,

--- a/valohai_cli/consts.py
+++ b/valohai_cli/consts.py
@@ -26,3 +26,6 @@ execution_statuses = incomplete_execution_statuses | complete_execution_statuses
 
 default_app_host = "https://app.valohai.com/"
 json_help_envvar = "VH_CLI_JSON_HELP"
+
+# Default environment API slug
+API_DEFAULT_ENVIRONMENT_SLUG = "PROJECT_DEFAULT"


### PR DESCRIPTION
If no environment is explicitly specified, instruct the API to use the project default environment.
Works with Roi `20250604.103429Z-93db42506` or newer.

Resolves #342 