### PR TITLE
🔨 Remove removed linter rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,6 @@ ignore = [
     "E501",
     "B904",
     "B905",
-    "ANN101", # Missing type annotation for `self` in method
-    "ANN102", # Missing type annotation for `cls` in classmethod
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
     "RET504", # Unnecessary variable assignment before `return` statement
     "SIM105", # Use `contextlib.suppress(TypeError)` instead of try-except-pass


### PR DESCRIPTION
[ANN101](https://docs.astral.sh/ruff/rules/missing-type-self/) and [ANN102](https://docs.astral.sh/ruff/rules/missing-type-cls/) have been removed from the Ruff ruleset, so ignoring them does nothing.