### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,12 @@ jobs:
           - "3.13"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "${{ matrix.python-version }}"
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          python-version: "${{ matrix.python-version }}"
           cache-dependency-glob: "**/pyproject.toml"
-      - run: uv pip install --system -e .[test]
-      - run: make test
+      - run: uv run --extra=test py.test -vvv --cov .
         env:
           EMAIL: foo@example.com
           GIT_AUTHOR_NAME: Foo Bar
@@ -48,10 +45,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v6
         with:
+          enable-cache: true
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@v5
       - run: uv build --wheel
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
         os:
           - ubuntu-22.04
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         python-version:
           - "3.9"
           - "3.10"
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: akx/pre-commit-uv-action@v0.1.0
   Build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.3
+    rev: v0.12.7
     hooks:
       - id: ruff
         args:
@@ -9,7 +9,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.17.0
     hooks:
       - id: mypy
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Command line client for Valohai"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Valohai", email = "hait@valohai.com" },
 ]
@@ -62,7 +62,7 @@ norecursedirs = [".git", ".tox"]
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 110
 preview = true
 

--- a/scripts/ensure_click_help.py
+++ b/scripts/ensure_click_help.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import argparse
 import ast
 import sys
-from typing import Any, List, Union
+from typing import Any
 
 
-def stringify_name(name: Union[None, ast.AST, ast.Name, str]) -> str:
+def stringify_name(name: ast.AST | ast.Name | str | None) -> str:
     if isinstance(name, ast.Attribute):
         return f"{stringify_name(name.value)}.{stringify_name(name.attr)}"
     if isinstance(name, ast.Name):
@@ -31,7 +33,7 @@ class EnsureClickHelpWalker(ast.NodeVisitor):
                     self.add_message(deco, "missing `help=`")
 
 
-def process_file(filename: str) -> List[str]:
+def process_file(filename: str) -> list[str]:
     with open(filename) as infp:
         tree = ast.parse(infp.read(), filename=filename)
 

--- a/tests/commands/execution/utils.py
+++ b/tests/commands/execution/utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Pattern
+from re import Pattern
 
 import requests_mock
 

--- a/tests/commands/yaml/utils.py
+++ b/tests/commands/yaml/utils.py
@@ -1,7 +1,7 @@
-from typing import Optional
+from __future__ import annotations
 
 
-def build_args(source_path: str, yaml_path: Optional[str] = None) -> list:
+def build_args(source_path: str, yaml_path: str | None = None) -> list:
     args = [source_path]
     if yaml_path:
         args.append(f"--yaml={yaml_path}")

--- a/tests/stub_git.py
+++ b/tests/stub_git.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import os
 import tempfile
 from pathlib import Path
 from subprocess import check_call, check_output
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any
 
 from valohai_cli.utils import get_random_string
 
@@ -39,9 +41,9 @@ class StubGit:
 
     def write(
         self,
-        path: Union[Path, str],
+        path: Path | str,
         *,
-        content: Optional[str] = None,
+        content: str | None = None,
         add: bool = True,
     ):
         if content is None:
@@ -54,7 +56,7 @@ class StubGit:
         if add:
             self.add(relative_path)
 
-    def add(self, path: Union[Path, str]):
+    def add(self, path: Path | str):
         _, relative_path = self._pathify(path)
         check_call(f"git add {relative_path}", cwd=self.dir_str, shell=True)
 
@@ -64,12 +66,12 @@ class StubGit:
     def commit(self, message: str = "bugfix"):
         check_call(f'git commit -m "{message}"', cwd=self.dir_str, shell=True)
 
-    def log(self) -> List[str]:
+    def log(self) -> list[str]:
         # full git commit SHAs in reverse chronological order (the latest first)
         raw = check_output("git log --pretty=format:%H", cwd=self.dir_str, shell=True)
         return raw.decode("utf-8").split()
 
-    def _pathify(self, path: Union[Path, str]) -> Tuple[Path, Path]:
+    def _pathify(self, path: Path | str) -> tuple[Path, Path]:
         if isinstance(path, str):
             path = Path(path)
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,6 +1,5 @@
 import os
 from subprocess import check_output
-from typing import Set
 
 import pytest
 from click import termui
@@ -40,7 +39,7 @@ def get_tar_files(tarball):
     return set(check_output(f"tar tf {tarball}", shell=True).decode("utf8").splitlines())
 
 
-def get_expected_filenames(original_set: Set[str], *, with_gitignore, with_vhignore) -> Set[str]:
+def get_expected_filenames(original_set: set[str], *, with_gitignore, with_vhignore) -> set[str]:
     new_set = original_set.copy()
     if with_vhignore:  # vhignore stops kahvikuppi
         new_set.discard("kahvikuppi")

--- a/valohai_cli/adhoc.py
+++ b/valohai_cli/adhoc.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import os
-from typing import Any, Dict, Optional
+from typing import Any
 
 import click
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
@@ -17,9 +19,9 @@ from valohai_cli.utils.hashing import get_fp_sha256
 def package_adhoc_commit(
     project: Project,
     validate: bool = True,
-    yaml_path: Optional[str] = None,
+    yaml_path: str | None = None,
     allow_git: bool = True,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create an ad-hoc tarball and commit of the project directory.
 
@@ -68,9 +70,9 @@ def create_adhoc_commit_from_tarball(
     *,
     project: Project,
     tarball: str,
-    yaml_path: Optional[str] = None,
+    yaml_path: str | None = None,
     description: str = "",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Using a precreated ad-hoc tarball, create or retrieve an ad-hoc commit of it on the Valohai host.
 
@@ -94,7 +96,7 @@ def create_adhoc_commit_from_tarball(
     return commit_obj
 
 
-def _get_pre_existing_commit(tarball: str, project_id: str) -> Optional[dict]:
+def _get_pre_existing_commit(tarball: str, project_id: str) -> dict | None:
     try:
         # This is the same mechanism used by the server to
         # calculate the identifier for an ad-hoc tarball.
@@ -102,7 +104,7 @@ def _get_pre_existing_commit(tarball: str, project_id: str) -> Optional[dict]:
             commit_identifier = f"~{get_fp_sha256(tarball_fp)}"
 
         # See if we have a commit with that identifier
-        commit_obj: Dict[str, Any] = request(
+        commit_obj: dict[str, Any] = request(
             "get",
             f"/api/v0/commits/{commit_identifier}/",
             params={"project": project_id},

--- a/valohai_cli/api.py
+++ b/valohai_cli/api.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import platform
-from typing import Any, Optional, Tuple, Union
+from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import click
@@ -28,7 +30,7 @@ def get_user_agent() -> str:
 
 
 class TokenAuth(AuthBase):
-    def __init__(self, netloc: str, token: Optional[str]) -> None:
+    def __init__(self, netloc: str, token: str | None) -> None:
         super().__init__()
         self.netloc = netloc
         self.token = token
@@ -47,9 +49,9 @@ class APISession(requests.Session):
     def __init__(
         self,
         base_url: str,
-        token: Optional[str] = None,
+        token: str | None = None,
         *,
-        verify_ssl: Union[bool, str] = True,
+        verify_ssl: bool | str = True,
     ) -> None:
         """
         :param verify_ssl: Path to a CA bundle to use,
@@ -99,7 +101,7 @@ def _get_current_api_session() -> APISession:
     host, token = get_host_and_token()
     ctx = click.get_current_context(silent=True) or None
     cache_key: str = force_text(f"_api_session_{host}_{token}")
-    session: Optional[APISession] = getattr(ctx, cache_key, None) if ctx else None
+    session: APISession | None = getattr(ctx, cache_key, None) if ctx else None
     if not session:
         session = APISession(
             base_url=host,
@@ -111,7 +113,7 @@ def _get_current_api_session() -> APISession:
     return session
 
 
-def get_host_and_token() -> Tuple[str, str]:
+def get_host_and_token() -> tuple[str, str]:
     host = settings.host
     token = settings.token
     if not (host and token):

--- a/valohai_cli/cli.py
+++ b/valohai_cli/cli.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import Optional
 
 import click
 
@@ -73,11 +74,11 @@ def cli(
     ctx: click.Context,
     debug: bool,
     output_format: str,
-    valohai_host: Optional[str],
-    valohai_token: Optional[str],
-    project_id: Optional[str],
-    project_mode: Optional[str],
-    project_root: Optional[str],
+    valohai_host: str | None,
+    valohai_token: str | None,
+    project_id: str | None,
+    project_mode: str | None,
+    project_root: str | None,
 ) -> None:
     if debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/valohai_cli/commands/deployment/create_version/create_version.py
+++ b/valohai_cli/commands/deployment/create_version/create_version.py
@@ -1,4 +1,6 @@
-from typing import Any, List, Optional
+from __future__ import annotations
+
+from typing import Any
 
 import click
 
@@ -72,14 +74,14 @@ from valohai_cli.utils.matching import match_from_list_with_error
 def create_version(
     ctx: click.Context,
     *,
-    args: List[str],
+    args: list[str],
     adhoc: bool,
     git_packaging: bool = True,
-    commit: Optional[str],
+    commit: str | None,
     deployment: str,
-    environment_variables: List[str],
-    endpoints: List[str],
-    version_name: Optional[str],
+    environment_variables: list[str],
+    endpoints: list[str],
+    version_name: str | None,
     inherit_env_vars: bool,
 ) -> Any:
     """

--- a/valohai_cli/commands/deployment/create_version/dynamic_creation_command.py
+++ b/valohai_cli/commands/deployment/create_version/dynamic_creation_command.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Optional
+from __future__ import annotations
+
+from typing import Any
 from uuid import UUID
 
 import click
@@ -29,12 +31,12 @@ class CreationCommand(click.Command):
     def __init__(
         self,
         project: Project,
-        deployment: Dict[str, Any],
-        endpoint_names: List[str],
+        deployment: dict[str, Any],
+        endpoint_names: list[str],
         commit: str,
         version_name: str,
         inherit_env_vars: bool = True,
-        environment_variables: Optional[Dict[str, str]] = None,
+        environment_variables: dict[str, str] | None = None,
     ) -> None:
         self.project = project
         self.deployment = deployment
@@ -94,7 +96,7 @@ class CreationCommand(click.Command):
             "enabled": True,
         }
 
-        endpoint_configurations: Dict[str, Any] = {}
+        endpoint_configurations: dict[str, Any] = {}
         endpoint_names_from_config = {e.name for e in self.config.endpoints.values()}
         for name in self.endpoint_names:
             if name not in endpoint_names_from_config:

--- a/valohai_cli/commands/execution/delete.py
+++ b/valohai_cli/commands/execution/delete.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 
 import click
 

--- a/valohai_cli/commands/execution/outputs.py
+++ b/valohai_cli/commands/execution/outputs.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import os
 import time
 from fnmatch import fnmatch
-from typing import List, Optional
 
 import click
 import requests
@@ -26,7 +27,7 @@ GLOB_HELP = (
 )
 
 
-def get_execution_outputs(execution: dict) -> List[dict]:
+def get_execution_outputs(execution: dict) -> list[dict]:
     return list(
         request(
             method="get",
@@ -70,8 +71,8 @@ def get_execution_outputs(execution: dict) -> List[dict]:
 )
 def outputs(
     counter: str,
-    download_directory: Optional[str],
-    filter_download: Optional[str],
+    download_directory: str | None,
+    filter_download: str | None,
     force: bool,
     sync: bool,
 ) -> None:
@@ -106,8 +107,8 @@ def outputs(
 def watch(
     counter: str,
     force: bool,
-    filter_download: Optional[str],
-    download_directory: Optional[str],
+    filter_download: str | None,
+    download_directory: str | None,
 ) -> None:
     if download_directory:
         info(f"Downloading to: {download_directory}\nWaiting for new outputs...")
@@ -132,11 +133,11 @@ def watch(
 
 
 def filter_outputs(
-    outputs: List[dict],
+    outputs: list[dict],
     download_directory: str,
-    filter_download: Optional[str],
+    filter_download: str | None,
     force: bool,
-) -> List[dict]:
+) -> list[dict]:
     if filter_download:
         outputs = [output for output in outputs if fnmatch(output["name"], filter_download)]
     if not force:
@@ -149,7 +150,7 @@ def filter_outputs(
     return outputs
 
 
-def download_outputs(outputs: List[dict], output_path: str, show_success_message: bool = True) -> None:
+def download_outputs(outputs: list[dict], output_path: str, show_success_message: bool = True) -> None:
     if not outputs:
         info("No outputs to download.")
         return
@@ -157,11 +158,14 @@ def download_outputs(outputs: List[dict], output_path: str, show_success_message
     num_width = len(str(len(outputs)))  # How many digits required to print the number of outputs
     start_time = time.time()
     is_responding_with_content = False
-    with click.progressbar(
-        length=total_size,
-        show_pos=True,
-        item_show_func=str,
-    ) as prog, requests.Session() as dl_sess:
+    with (
+        click.progressbar(
+            length=total_size,
+            show_pos=True,
+            item_show_func=str,
+        ) as prog,
+        requests.Session() as dl_sess,
+    ):
         dl_sess.headers["User-Agent"] = f"{get_user_agent()} (downloader)"
         for i, output in enumerate(outputs, 1):
             name = output["name"]

--- a/valohai_cli/commands/execution/run/dynamic_run_command.py
+++ b/valohai_cli/commands/execution/run/dynamic_run_command.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import collections
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from collections.abc import Sequence
+from typing import Any
 
 import click
 from click import get_current_context
@@ -22,7 +25,7 @@ from ..ssh import ssh
 from .excs import ExecutionCreationAPIError
 
 
-def generate_sanitized_options(name: str) -> Set[str]:
+def generate_sanitized_options(name: str) -> set[str]:
     sanitized_name = sanitize_option_name(name)
     return {
         choice
@@ -45,27 +48,27 @@ class RunCommand(click.Command):
         "flag": click.BOOL,
     }
 
-    environment_variable_groups: Optional[List[str]]
+    environment_variable_groups: list[str] | None
 
     def __init__(
         self,
         project: Project,
         step: Step,
         commit: str,
-        environment: Optional[str] = None,
-        image: Optional[str] = None,
-        title: Optional[str] = None,
+        environment: str | None = None,
+        image: str | None = None,
+        title: str | None = None,
         watch: bool = False,
         open_browser: bool = False,
-        download_directory: Optional[str] = None,
-        environment_variables: Optional[Dict[str, str]] = None,
-        environment_variable_groups: Optional[Sequence[str]] = None,
-        tags: Optional[Sequence[str]] = None,
-        runtime_config: Optional[dict] = None,
-        runtime_config_preset: Optional[str] = None,
+        download_directory: str | None = None,
+        environment_variables: dict[str, str] | None = None,
+        environment_variable_groups: Sequence[str] | None = None,
+        tags: Sequence[str] | None = None,
+        runtime_config: dict | None = None,
+        runtime_config_preset: str | None = None,
         ssh: bool = False,
-        priority: Optional[int] = None,
-        time_limit: Optional[str] = None,
+        priority: int | None = None,
+        time_limit: str | None = None,
     ) -> None:
         """
         Initialize the dynamic run command.
@@ -256,7 +259,7 @@ class RunCommand(click.Command):
             return {}
         return {attribute_name: value}
 
-    def _sift_kwargs(self, kwargs: Dict[str, str]) -> Tuple[dict, dict, dict]:
+    def _sift_kwargs(self, kwargs: dict[str, str]) -> tuple[dict, dict, dict]:
         # Sift kwargs into params, options, and inputs
         options = {}
         params = {}
@@ -271,7 +274,7 @@ class RunCommand(click.Command):
         self._process_parameters(params, parameter_file=options.get("parameter_file"))
         return options, params, inputs
 
-    def _process_parameters(self, parameters: Dict[str, Any], parameter_file: Optional[str]) -> None:  # noqa: C901
+    def _process_parameters(self, parameters: dict[str, Any], parameter_file: str | None) -> None:  # noqa: C901
         if parameter_file:
             parameter_file_data = read_data_file(parameter_file)
             if not isinstance(parameter_file_data, dict):

--- a/valohai_cli/commands/execution/run/excs.py
+++ b/valohai_cli/commands/execution/run/excs.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 import click
 

--- a/valohai_cli/commands/execution/run/frontend_command.py
+++ b/valohai_cli/commands/execution/run/frontend_command.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import contextlib
-from typing import Any, List, Optional
+from typing import Any
 
 import click
 
@@ -181,31 +183,31 @@ def run(
     *,
     adhoc: bool,
     git_packaging: bool = True,
-    args: List[str],
-    commit: Optional[str],
-    yaml: Optional[str],
-    download_directory: Optional[str],
-    environment: Optional[str],
-    environment_variables: List[str],
-    environment_variable_groups: Optional[List[str]],
-    image: Optional[str],
-    step_name: Optional[str],
-    tags: List[str],
-    title: Optional[str],
+    args: list[str],
+    commit: str | None,
+    yaml: str | None,
+    download_directory: str | None,
+    environment: str | None,
+    environment_variables: list[str],
+    environment_variable_groups: list[str] | None,
+    image: str | None,
+    step_name: str | None,
+    tags: list[str],
+    title: str | None,
     validate_adhoc: bool,
     watch: bool,
     open_browser: bool,
     debug_port: int,
-    debug_key_file: Optional[str],
+    debug_key_file: str | None,
     autorestart: bool,
-    priority: Optional[int],
-    k8s_cpu_min: Optional[float],
-    k8s_memory_min: Optional[int],
-    k8s_cpu_max: Optional[float],
-    k8s_memory_max: Optional[int],
-    k8s_devices: List[str],
+    priority: int | None,
+    k8s_cpu_min: float | None,
+    k8s_memory_min: int | None,
+    k8s_cpu_max: float | None,
+    k8s_memory_max: int | None,
+    k8s_devices: list[str],
     k8s_device_none: bool,
-    k8s_preset: Optional[str],
+    k8s_preset: str | None,
     ssh: bool = False,
 ) -> Any:
     """
@@ -326,7 +328,7 @@ def run(
         return rc.invoke(child_ctx)
 
 
-def print_step_list(ctx: click.Context, commit: Optional[str]) -> None:
+def print_step_list(ctx: click.Context, commit: str | None) -> None:
     with contextlib.suppress(Exception):  # If we fail to extract the step list, it's not that big of a deal.
         config = get_project(require=True).get_config(commit_identifier=commit)
         if config.steps:

--- a/valohai_cli/commands/execution/stop.py
+++ b/valohai_cli/commands/execution/stop.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from __future__ import annotations
+
+from typing import Any
 
 import click
 
@@ -20,7 +22,7 @@ from valohai_cli.utils.cli_utils import HelpfulArgument
 @click.option("--all", default=None, is_flag=True, help="Stop all in-progress executions.")
 @click.command()
 def stop(
-    counters: Optional[Union[List[str], Tuple[str]]] = None,
+    counters: list[str] | tuple[str] | None = None,
     all: bool = False,
 ) -> None:
     """
@@ -53,8 +55,8 @@ def stop(
     success("Done.")
 
 
-def get_executions_for_stop(project: Project, counters: Optional[List[str]], *, all: bool) -> List[dict]:
-    params: Dict[str, Any] = {"project": project.id}
+def get_executions_for_stop(project: Project, counters: list[str] | None, *, all: bool) -> list[dict]:
+    params: dict[str, Any] = {"project": project.id}
     if counters == ["latest"]:
         return [project.get_execution_from_counter("latest")]
 

--- a/valohai_cli/commands/execution/summarize.py
+++ b/valohai_cli/commands/execution/summarize.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Sequence
+from collections.abc import Sequence
 
 import click
 
@@ -9,7 +9,7 @@ from valohai_cli.table import print_table
 from valohai_cli.utils import subset_keys
 
 
-def download_execution_data(project: Project, counters: Sequence[str]) -> Dict[str, dict]:
+def download_execution_data(project: Project, counters: Sequence[str]) -> dict[str, dict]:
     executions = {}
     with click.progressbar(
         IntegerRange.parse(counters).as_set(),
@@ -28,7 +28,7 @@ def download_execution_data(project: Project, counters: Sequence[str]) -> Dict[s
 
 @click.command()
 @click.argument("counters", required=True, nargs=-1)
-def summarize(counters: List[str]) -> None:
+def summarize(counters: list[str]) -> None:
     """
     Summarize execution metadata.
 

--- a/valohai_cli/commands/execution/watch.py
+++ b/valohai_cli/commands/execution/watch.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import datetime
 import time
-from typing import Dict, List, Optional
 
 import click
 from click import get_current_context
@@ -16,7 +17,7 @@ from valohai_cli.utils.cli_utils import counter_argument
 
 
 class WatchTUI:
-    status_styles: Dict[str, dict] = {
+    status_styles: dict[str, dict] = {
         "started": {"fg": "blue", "bold": True},
         "crashed": {"fg": "white", "bg": "red"},
         "stopped": {"fg": "red"},
@@ -26,9 +27,9 @@ class WatchTUI:
     def __init__(self, execution: dict) -> None:
         self.execution = execution
         self.log_manager = LogManager(execution)
-        self.events: List[dict] = []
+        self.events: list[dict] = []
         self.n_events = 0
-        self.status_text: Optional[str] = None
+        self.status_text: str | None = None
 
     def refresh(self) -> None:
         try:

--- a/valohai_cli/commands/init.py
+++ b/valohai_cli/commands/init.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import os
 import shutil
 import sys
-from typing import Optional
 
 import click
 
@@ -79,7 +80,7 @@ def init() -> None:
     click.secho("*" * width, fg="green", bold=True)
 
 
-def link_or_create_prompt(cwd: str) -> Optional[Project]:
+def link_or_create_prompt(cwd: str) -> Project | None:
     while True:
         response = (
             click.prompt(

--- a/valohai_cli/commands/lint.py
+++ b/valohai_cli/commands/lint.py
@@ -1,5 +1,4 @@
 import os
-from typing import List
 
 import click
 from valohai_yaml.lint import lint_file
@@ -31,7 +30,7 @@ def validate_file(filename: str) -> int:
 
 @click.command()
 @click.argument("filenames", nargs=-1, type=click.Path(file_okay=True, exists=True, dir_okay=False))
-def lint(filenames: List[str]) -> None:
+def lint(filenames: list[str]) -> None:
     """
     Lint (syntax-check) a valohai.yaml file.
 

--- a/valohai_cli/commands/login.py
+++ b/valohai_cli/commands/login.py
@@ -1,4 +1,5 @@
-from typing import Optional, Union
+from __future__ import annotations
+
 from urllib.parse import urljoin, urlparse
 
 import click
@@ -58,11 +59,11 @@ Use a login token instead:
 def login(
     username: str,
     password: str,
-    token: Optional[str],
-    host: Optional[str],
+    token: str | None,
+    host: str | None,
     yes: bool,
-    verify_ssl: Union[bool, str],
-    ca_file: Optional[str],
+    verify_ssl: bool | str,
+    ca_file: str | None,
 ) -> None:
     """Log in into Valohai."""
     if settings.user and settings.token:
@@ -117,7 +118,7 @@ def login(
         warn("SSL verification is off. This may leave you vulnerable to man-in-the-middle attacks.")
 
 
-def verify_token(*, host: str, token: str, verify_ssl: Union[bool, str] = True) -> dict:
+def verify_token(*, host: str, token: str, verify_ssl: bool | str = True) -> dict:
     click.echo(f"Verifying API token on {host}...")
     with APISession(host, token, verify_ssl=verify_ssl) as sess:
         return sess.get("/api/v0/users/me/").json()
@@ -126,9 +127,9 @@ def verify_token(*, host: str, token: str, verify_ssl: Union[bool, str] = True) 
 def do_user_pass_login(
     *,
     host: str,
-    username: Optional[str] = None,
-    password: Optional[str] = None,
-    verify_ssl: Union[bool, str] = True,
+    username: str | None = None,
+    password: str | None = None,
+    verify_ssl: bool | str = True,
 ) -> str:
     click.echo(f"\nIf you don't yet have an account, please create one at {host} first.\n")
     if not username:
@@ -161,8 +162,8 @@ def do_user_pass_login(
 def do_interactive_token_login(
     *,
     host: str,
-    verify_ssl: Union[bool, str] = True,
-    login_error_code: Optional[str] = None,
+    verify_ssl: bool | str = True,
+    login_error_code: str | None = None,
 ) -> str:
     banner(
         TOKEN_LOGIN_HELP.format(
@@ -181,7 +182,7 @@ def do_interactive_token_login(
         return token
 
 
-def validate_host(host: Optional[str]) -> str:
+def validate_host(host: str | None) -> str:
     default_host = (
         settings.overrides.get("host")  # from the top-level CLI (or envvar) ...
         or default_app_host  # ... or the global default

--- a/valohai_cli/commands/notebook/run/run.py
+++ b/valohai_cli/commands/notebook/run/run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import click
 

--- a/valohai_cli/commands/parcel.py
+++ b/valohai_cli/commands/parcel.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import os
 import shutil
 import subprocess
 import sys
 import time
-from typing import Iterable, List, Optional
+from collections.abc import Iterable
 
 import click
 
@@ -71,8 +73,8 @@ def print_parcel_progress(text: str) -> None:
     help="Add unparcel script?",
 )
 def parcel(
-    destination: Optional[str],
-    commit: Optional[str],
+    destination: str | None,
+    commit: str | None,
     code: str,
     valohai_local_run: bool,
     docker_images: bool,
@@ -93,7 +95,7 @@ def parcel(
 
     ensure_makedirs(destination)
 
-    extra_docker_images: List[str] = []
+    extra_docker_images: list[str] = []
 
     if code in ("bundle", "archive", "tarball"):
         export_code(project, destination, mode=code)
@@ -163,7 +165,7 @@ def export_code(project: Project, destination: str, mode: str) -> None:
         raise NotImplementedError("...")
 
 
-def get_docker_image_size(image: str) -> Optional[int]:
+def get_docker_image_size(image: str) -> int | None:
     """
     Try to get the size of the given Docker image in bytes.
     :param image: The image name.
@@ -190,7 +192,7 @@ def get_docker_image_size(image: str) -> Optional[int]:
 def export_docker_images(
     project: Project,
     destination: str,
-    commit: Optional[str],
+    commit: str | None,
     extra_docker_images: Iterable[str] = (),
 ) -> None:
     commit = expand_commit_id(project.directory, commit=(commit or "HEAD"))

--- a/valohai_cli/commands/pipeline/run/run.py
+++ b/valohai_cli/commands/pipeline/run/run.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import contextlib
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import click
 from click import Context
@@ -75,15 +77,15 @@ from valohai_cli.utils.commits import create_or_resolve_commit
 def run(
     ctx: Context,
     *,
-    name: Optional[str],
-    commit: Optional[str],
-    title: Optional[str],
+    name: str | None,
+    commit: str | None,
+    title: str | None,
     adhoc: bool,
     git_packaging: bool = True,
-    yaml: Optional[str],
-    tags: List[str],
-    environment: Optional[str],
-    args: List[str],
+    yaml: str | None,
+    tags: list[str],
+    environment: str | None,
+    args: list[str],
 ) -> None:
     """
     Start a pipeline run.
@@ -125,14 +127,14 @@ def run(
     )
 
 
-def process_args(args: List[str]) -> Dict[str, Union[str, list]]:
-    args_dict: Dict[str, Union[str, list]] = {}
+def process_args(args: list[str]) -> dict[str, str | list]:
+    args_dict: dict[str, str | list] = {}
     for i, arg in enumerate(args):
         if arg.startswith("--"):
             arg_name = arg.lstrip("-")
             if "+=" in arg_name:  # --param+=value
                 name, value = arg_name.split("+=", 1)
-                value_list: Union[list, str] = args_dict.get(name) or []
+                value_list: list | str = args_dict.get(name) or []
                 if not isinstance(value_list, list):
                     raise click.UsageError(f'[{name}] Cannot mix "+=" with other parameter assignments')
                 value_list.append(value)
@@ -155,7 +157,7 @@ def process_args(args: List[str]) -> Dict[str, Union[str, list]]:
     return args_dict
 
 
-def print_pipeline_list(ctx: Context, commit: Optional[str]) -> None:
+def print_pipeline_list(ctx: Context, commit: str | None) -> None:
     with contextlib.suppress(
         Exception,
     ):  # If we fail to extract the pipeline list, it's not that big of a deal.
@@ -178,12 +180,12 @@ def start_pipeline(
     pipeline: Pipeline,
     project_id: str,
     commit: str,
-    tags: List[str],
-    args: List[str],
-    title: Optional[str] = None,
-    override_environment: Optional[str] = None,
+    tags: list[str],
+    args: list[str],
+    title: str | None = None,
+    override_environment: str | None = None,
 ) -> None:
-    args_dict: Dict[str, Union[str, list]]
+    args_dict: dict[str, str | list]
     args_dict = process_args(args) if args else {}
 
     converter = PipelineConverter(config=config, commit_identifier=commit, parameter_arguments=args_dict)
@@ -202,7 +204,7 @@ def start_pipeline(
             )
         raise click.UsageError(f"Unknown pipeline parameters: {unused_args}")
 
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "project": project_id,
         "title": title or pipeline.name,
         "tags": tags,

--- a/valohai_cli/commands/project/create.py
+++ b/valohai_cli/commands/project/create.py
@@ -1,4 +1,6 @@
-from typing import Any, Callable, List, Optional
+from __future__ import annotations
+
+from typing import Any, Callable
 
 import click
 from click import prompt
@@ -21,7 +23,7 @@ def create_project(
     directory: str,
     name: str,
     description: str = "",
-    owner: Optional[str] = None,
+    owner: str | None = None,
     link: bool = True,
     yes: bool = False,
 ) -> None:
@@ -54,10 +56,10 @@ def create_project(
 def prompt_for_owner(
     *,
     command_prompt: str,
-    value_proc: Optional[Callable[[Any], Any]] = None,
-) -> Optional[str]:
+    value_proc: Callable[[Any], Any] | None = None,
+) -> str | None:
     try:
-        options: List[str] = request("get", "/api/v0/projects/ownership_options/").json()
+        options: list[str] = request("get", "/api/v0/projects/ownership_options/").json()
     except APINotFoundError:  # Endpoint not there, ah well!
         return None
     except APIError as ae:
@@ -82,7 +84,7 @@ def prompt_for_owner(
 
 
 class OwnerOptionsOption(click.Option):
-    def prompt_for_value(self, ctx: Context) -> Optional[str]:
+    def prompt_for_value(self, ctx: Context) -> str | None:
         return prompt_for_owner(
             command_prompt=self.prompt or "Owner",
             value_proc=lambda x: self.process_value(ctx, x),
@@ -119,7 +121,7 @@ class OwnerOptionsOption(click.Option):
     help="Link the directory to the newly created project? Default yes.",
 )
 @yes_option
-def create(name: str, description: str, link: bool, owner: Optional[str], yes: bool) -> None:
+def create(name: str, description: str, link: bool, owner: str | None, yes: bool) -> None:
     """Create a new project and optionally link it to the directory."""
     create_project(
         directory=get_project_directory(),

--- a/valohai_cli/commands/project/link.py
+++ b/valohai_cli/commands/project/link.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import contextlib
-from typing import Any, List, Optional, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import click
 
@@ -16,14 +19,14 @@ class NewProjectInstead(Exception):
     pass
 
 
-def filter_projects(projects: Sequence[dict], spec: str) -> List[dict]:
+def filter_projects(projects: Sequence[dict], spec: str) -> list[dict]:
     spec = str(spec).lower()
     return [
         project for project in projects if project["id"].lower() == spec or project["name"].lower() == spec
     ]
 
 
-def choose_project(dir: str, spec: Optional[str] = None) -> Optional[dict]:
+def choose_project(dir: str, spec: str | None = None) -> dict | None:
     """
     Choose a project, possibly interactively.
 
@@ -31,7 +34,7 @@ def choose_project(dir: str, spec: Optional[str] = None) -> Optional[dict]:
     :param spec: An optional search string
     :return: project object or None
     """
-    projects: List[dict] = request("get", "/api/v0/projects/", params={"limit": "1000"}).json()["results"]
+    projects: list[dict] = request("get", "/api/v0/projects/", params={"limit": "1000"}).json()["results"]
     if not projects:
         if click.confirm("You don't have any projects. Create one instead?"):
             raise NewProjectInstead()
@@ -70,7 +73,7 @@ def choose_project(dir: str, spec: Optional[str] = None) -> Optional[dict]:
 @click.command()
 @click.argument("project", default=None, required=False)
 @yes_option
-def link(project: Optional[str], yes: bool) -> Any:
+def link(project: str | None, yes: bool) -> Any:
     """
     Link a directory with a Valohai project.
     """

--- a/valohai_cli/commands/update_check.py
+++ b/valohai_cli/commands/update_check.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import sys
-from typing import Optional
 
 import click
 import requests
@@ -41,7 +42,7 @@ def update_check() -> None:
         click.echo("\nYou seem to be running the latest and greatest. Good on you!")
 
 
-def determine_upgrade_status(current_version: str, latest_version: str) -> Optional[str]:
+def determine_upgrade_status(current_version: str, latest_version: str) -> str | None:
     try:
         from distutils.version import LooseVersion
 

--- a/valohai_cli/commands/yaml/pipeline.py
+++ b/valohai_cli/commands/yaml/pipeline.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from __future__ import annotations
 
 import click
 from valohai.internals.pipeline import get_pipeline_from_source
@@ -17,7 +17,7 @@ from valohai_cli.messages import error, info
     type=click.Path(file_okay=True, exists=True, dir_okay=False),
     required=True,
 )
-def pipeline(filenames: List[str], yaml: Optional[str]) -> None:
+def pipeline(filenames: list[str], yaml: str | None) -> None:
     """
     Update a pipeline config(s) in valohai.yaml based on Python source file(s).
     Python source file is expected to have def main(config: Config) -> Pipeline

--- a/valohai_cli/commands/yaml/step.py
+++ b/valohai_cli/commands/yaml/step.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import os
-from typing import List, Optional
 
 import click
 from valohai.internals.merge import python_to_yaml_merge_strategy
@@ -20,7 +21,7 @@ from valohai_cli.models.project import Project
     type=click.Path(file_okay=True, exists=True, dir_okay=False),
     required=True,
 )
-def step(filenames: List[str], yaml: Optional[str]) -> None:
+def step(filenames: list[str], yaml: str | None) -> None:
     """
     Update a step config(s) in valohai.yaml based on Python source file(s).
 
@@ -52,14 +53,14 @@ def step(filenames: List[str], yaml: Optional[str]) -> None:
             info(f"{yaml} already up-to-date.")
 
 
-def get_current_config(project: Project, yaml_file: Optional[str] = None) -> Optional[Config]:
+def get_current_config(project: Project, yaml_file: str | None = None) -> Config | None:
     try:
         return project.get_config(yaml_path=yaml_file)
     except FileNotFoundError:
         return None
 
 
-def get_updated_config(source_path: str, project: Project, yaml_file: Optional[str] = None) -> Config:
+def get_updated_config(source_path: str, project: Project, yaml_file: str | None = None) -> Config:
     """Opens the old valohai.yaml, parses source Python file and merges the resulting config to the old
 
     Call to valohai.prepare() will contain step name, parameters and inputs.
@@ -78,7 +79,7 @@ def get_updated_config(source_path: str, project: Project, yaml_file: Optional[s
     return new_config
 
 
-def update_yaml_from_source(source_path: str, project: Project, yaml_file: Optional[str]) -> bool:
+def update_yaml_from_source(source_path: str, project: Project, yaml_file: str | None) -> bool:
     """Updates valohai.yaml by parsing the source code file for a call to valohai.prepare()
 
     Call to valohai.prepare() will contain step name, parameters and inputs.
@@ -98,7 +99,7 @@ def update_yaml_from_source(source_path: str, project: Project, yaml_file: Optio
     return False
 
 
-def yaml_needs_update(source_path: str, project: Project, yaml_file: Optional[str]) -> bool:
+def yaml_needs_update(source_path: str, project: Project, yaml_file: str | None) -> bool:
     """Checks if valohai.yaml needs updating based on source Python code.
 
     Call to valohai.prepare() will contain step name, parameters and inputs.

--- a/valohai_cli/ctx.py
+++ b/valohai_cli/ctx.py
@@ -1,4 +1,6 @@
-from typing import Literal, Optional, Union, overload
+from __future__ import annotations
+
+from typing import Literal, Union, overload
 
 import click
 
@@ -13,17 +15,17 @@ ProjectOrRemoteProject = Union[RemoteProject, Project]
 
 
 @overload
-def get_project(dir: Optional[str] = None, require: Literal[True] = True) -> ProjectOrRemoteProject: ...
+def get_project(dir: str | None = None, require: Literal[True] = True) -> ProjectOrRemoteProject: ...
 
 
 @overload
 def get_project(
-    dir: Optional[str] = None,
+    dir: str | None = None,
     require: Literal[False] = False,
-) -> Optional[ProjectOrRemoteProject]: ...
+) -> ProjectOrRemoteProject | None: ...
 
 
-def get_project(dir: Optional[str] = None, require: bool = False) -> Optional[ProjectOrRemoteProject]:
+def get_project(dir: str | None = None, require: bool = False) -> ProjectOrRemoteProject | None:
     """
     Get the Valohai project object for a directory context.
 

--- a/valohai_cli/exceptions.py
+++ b/valohai_cli/exceptions.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
 from pprint import pformat
-from typing import Any, Iterable, Optional, Union
+from typing import Any
 
 import click
 from click import ClickException
@@ -10,11 +13,11 @@ class CLIException(ClickException):
     kind: str = "Error"
     color: str = "red"
 
-    def __init__(self, message: str, kind: Optional[str] = None) -> None:
+    def __init__(self, message: str, kind: str | None = None) -> None:
         super().__init__(message)
         self.kind = str(kind or self.kind)
 
-    def show(self, file: Optional[Any] = None) -> None:
+    def show(self, file: Any | None = None) -> None:
         formatted_message = self.format_message()
         if formatted_message and "\n" in formatted_message:
             # If there are newlines in the message, we'll format things a little differently.
@@ -47,7 +50,7 @@ class APIError(CLIException):
         self.request = response.request
 
     @property
-    def error_json(self) -> Union[None, dict, list]:
+    def error_json(self) -> dict | list | None:
         try:
             error_json = self.response.json()
             if isinstance(error_json, (dict, list)):
@@ -57,7 +60,7 @@ class APIError(CLIException):
         return None
 
     @property
-    def code(self) -> Optional[Any]:
+    def code(self) -> Any | None:
         """
         Attempt to retrieve a top-level error code from the response.
         """

--- a/valohai_cli/git.py
+++ b/valohai_cli/git.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import Sequence
+from collections.abc import Sequence
 
 from valohai_cli.exceptions import NoCommit, NoGitRepo
 

--- a/valohai_cli/log_manager.py
+++ b/valohai_cli/log_manager.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import hashlib
-from typing import Optional, Set
 
 from valohai_cli.api import request
 from valohai_cli.utils import force_bytes
@@ -10,13 +11,13 @@ class LogManager:
         self.execution: dict = execution
         self.execution_url: str = execution["url"]
         self.events_url: str = f"{self.execution_url}events/"
-        self.seen_events: Set[str] = set()
+        self.seen_events: set[str] = set()
 
     def update_execution(self) -> dict:
         self.execution = request("get", self.execution_url).json()
         return self.execution
 
-    def fetch_events(self, limit: Optional[int] = None) -> dict:
+    def fetch_events(self, limit: int | None = None) -> dict:
         params = {}
         if limit is not None:
             params["limit"] = limit

--- a/valohai_cli/messages.py
+++ b/valohai_cli/messages.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import random
 import sys
-from typing import List, Optional
 
 import click
 
@@ -53,9 +54,9 @@ if sys.platform != "win32":
 
 def _format_message(
     message: str,
-    emoji: Optional[List[str]] = None,
-    prefix: Optional[str] = None,
-    color: Optional[str] = None,
+    emoji: list[str] | None = None,
+    prefix: str | None = None,
+    color: str | None = None,
 ) -> str:
     selected_emoji = random.choice(emoji or [""])
     formatted_prefix = click.style(prefix, fg=color, bold=True) if prefix else ""
@@ -86,7 +87,7 @@ def progress(message: str, err: bool = True) -> None:
 DEFAULT_BANNER_STYLE = {"fg": "magenta", "bold": True}
 
 
-def banner(message: str, banner_char: str = "=", banner_style: Optional[dict] = None) -> None:
+def banner(message: str, banner_char: str = "=", banner_style: dict | None = None) -> None:
     if banner_style is None:
         banner_style = DEFAULT_BANNER_STYLE
 

--- a/valohai_cli/models/project.py
+++ b/valohai_cli/models/project.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import io
 import os
-from typing import List, Optional, TextIO, Union
+from typing import TextIO
 
 import valohai_yaml
 from click import BadParameter
@@ -19,7 +21,7 @@ class Project:
         if not os.path.isdir(directory):
             raise ValueError(f"Invalid directory: {directory}")
         self.directory = directory
-        self._commit_list: Optional[List[dict]] = None
+        self._commit_list: list[dict] | None = None
 
     @property
     def id(self) -> str:
@@ -29,7 +31,7 @@ class Project:
     def name(self) -> str:
         return str(self.data["name"])
 
-    def get_config(self, commit_identifier: Optional[str] = None, yaml_path: Optional[str] = None) -> Config:
+    def get_config(self, commit_identifier: str | None = None, yaml_path: str | None = None) -> Config:
         """
         Get the `valohai_yaml.Config` object from the current working directory,
         or a given commit.
@@ -58,7 +60,7 @@ class Project:
         except valohai_yaml.ValidationErrors as ves:
             raise InvalidConfig(f"{filename} is invalid ({len(ves.errors)} errors); see `vh lint`")
 
-    def get_config_filename(self, yaml_path: Optional[str] = None) -> str:
+    def get_config_filename(self, yaml_path: str | None = None) -> str:
         used_yaml_path = yaml_path or self.get_yaml_path()
         return os.path.join(self.directory, used_yaml_path)
 
@@ -68,8 +70,8 @@ class Project:
 
     def get_execution_from_counter(
         self,
-        counter: Union[int, str],
-        params: Optional[dict] = None,
+        counter: int | str,
+        params: dict | None = None,
     ) -> dict:
         if isinstance(counter, str):
             counter = counter.lstrip("#")
@@ -90,12 +92,12 @@ class Project:
                 raise NoExecution(f"Execution #{counter} does not exist")
             raise
 
-    def load_commit_list(self) -> List[dict]:
+    def load_commit_list(self) -> list[dict]:
         """
         Get a list of non-adhoc commits, newest first.
         """
         if self._commit_list is None:
-            commits: List[dict] = list(
+            commits: list[dict] = list(
                 request(
                     method="get",
                     url="/api/v0/commits/",
@@ -110,7 +112,7 @@ class Project:
             self._commit_list = commits
         return self._commit_list
 
-    def resolve_commits(self, commit_identifier: Optional[str] = None) -> List[dict]:
+    def resolve_commits(self, commit_identifier: str | None = None) -> list[dict]:
         """
         Resolve a commit identifier to a list of matching commit dicts.
 
@@ -148,7 +150,7 @@ class Project:
         assert newest_commit["identifier"]
         return [newest_commit]
 
-    def load_full_commit(self, identifier: Optional[str] = None) -> dict:
+    def load_full_commit(self, identifier: str | None = None) -> dict:
         """
         Load the commit object including config data (as a dict) from the Valohai host for the given commit identifier.
 

--- a/valohai_cli/models/remote_project.py
+++ b/valohai_cli/models/remote_project.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from valohai_yaml.objs.config import Config
 
@@ -8,7 +8,7 @@ from valohai_cli.models.project import Project
 class RemoteProject(Project):
     is_remote = True
 
-    def get_config(self, commit_identifier: Optional[str] = None, yaml_path: Optional[str] = None) -> Config:  # noqa: ARG002
+    def get_config(self, commit_identifier: str | None = None, yaml_path: str | None = None) -> Config:  # noqa: ARG002
         if not commit_identifier:
             raise ValueError("RemoteProjects require an explicit commit identifier")
         commit = self.load_full_commit(commit_identifier)
@@ -18,6 +18,6 @@ class RemoteProject(Project):
 
     def get_config_filename(
         self,
-        yaml_path: Optional[str] = None,
+        yaml_path: str | None = None,
     ) -> str:  # pragma: no cover  # typing: ignore[override]
         raise NotImplementedError("RemoteProject.get_config_filename() should never get called")

--- a/valohai_cli/override.py
+++ b/valohai_cli/override.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import os
-from typing import Optional
 
 import click
 
@@ -8,13 +9,13 @@ from valohai_cli.messages import info
 from valohai_cli.settings import settings
 
 
-def configure_token_login(host: Optional[str], token: str) -> None:
+def configure_token_login(host: str | None, token: str) -> None:
     settings.overrides["host"] = host or default_app_host
     settings.overrides["user"] = {"id": "<none>", "username": "<logged in via --valohai-token>"}
     settings.overrides["token"] = token
 
 
-def configure_project_override(project_id: str, mode: Optional[str], directory: Optional[str] = None) -> None:
+def configure_project_override(project_id: str, mode: str | None, directory: str | None = None) -> None:
     if not directory:
         directory = os.getcwd()
     if not mode:

--- a/valohai_cli/packager.py
+++ b/valohai_cli/packager.py
@@ -5,9 +5,10 @@ import subprocess
 import tarfile
 import tempfile
 from collections import namedtuple
+from collections.abc import Iterable
 from enum import Enum
 from subprocess import check_output
-from typing import IO, Dict, Iterable, List, Tuple
+from typing import IO
 
 import click
 import gitignorant
@@ -88,7 +89,7 @@ def package_directory(
 
 def package_files_into(
     dest_fp: IO[bytes],
-    file_stats: Dict[str, PackageFileInfo],
+    file_stats: dict[str, PackageFileInfo],
     progress: bool = False,
 ) -> None:
     """
@@ -131,7 +132,7 @@ def package_files_into(
     dest_fp.flush()
 
 
-def _get_files_with_git(dir: str) -> Iterable[Tuple[str, str]]:
+def _get_files_with_git(dir: str) -> Iterable[tuple[str, str]]:
     paths_seen = set()
     commands = [
         "git ls-files --exclude-standard -ocz",
@@ -155,7 +156,7 @@ def _get_files_with_git(dir: str) -> Iterable[Tuple[str, str]]:
                 yield (file, path)
 
 
-def _get_files_walk(dir: str) -> Iterable[Tuple[str, str]]:
+def _get_files_walk(dir: str) -> Iterable[tuple[str, str]]:
     for dirpath, dirnames, filenames in os.walk(dir):
         dirnames[:] = [dirname for dirname in dirnames if not dirname.startswith(".")]
         for filename in filenames:
@@ -167,7 +168,7 @@ def _get_files_walk(dir: str) -> Iterable[Tuple[str, str]]:
             yield (file_rel_path, file_abs_path)
 
 
-def _get_files_inner(dir: str, allow_git: bool = True) -> Tuple[GitUsage, Iterable[Tuple[str, str]]]:
+def _get_files_inner(dir: str, allow_git: bool = True) -> tuple[GitUsage, Iterable[tuple[str, str]]]:
     # Inner, pre-vhignore-supporting generator function...
     gitignore_path = os.path.join(dir, ".gitignore")
 
@@ -198,7 +199,7 @@ def _get_files_inner(dir: str, allow_git: bool = True) -> Tuple[GitUsage, Iterab
     return (GitUsage.NONE, _get_files_walk(dir))  # return the generator
 
 
-def _get_files(dir: str, allow_git: bool = True) -> Tuple[GitUsage, VhIgnoreUsage, Iterable[Tuple[str, str]]]:
+def _get_files(dir: str, allow_git: bool = True) -> tuple[GitUsage, VhIgnoreUsage, Iterable[tuple[str, str]]]:
     git_usage, ftup_gen = _get_files_inner(dir, allow_git=allow_git)
     vhignore_path = os.path.join(dir, ".vhignore")
 
@@ -226,7 +227,7 @@ def get_files_for_package(
     dir: str,
     allow_git: bool = True,
     ignore_patterns: Iterable[str] = (),
-) -> Dict[str, PackageFileInfo]:
+) -> dict[str, PackageFileInfo]:
     """
     Get files to package for ad-hoc packaging from the file system.
 
@@ -276,7 +277,7 @@ def _get_packaging_info_message(count: int, git_usage: GitUsage, vhignore_usage:
     )
 
 
-def validate_package_size(file_stats: Dict[str, PackageFileInfo]) -> List[str]:
+def validate_package_size(file_stats: dict[str, PackageFileInfo]) -> list[str]:
     warnings = []
     total_uncompressed_size = 0
     for file, pfi in sorted(file_stats.items()):

--- a/valohai_cli/range.py
+++ b/valohai_cli/range.py
@@ -1,15 +1,17 @@
-from typing import Iterable, Set, Union
+from __future__ import annotations
+
+from collections.abc import Iterable
 
 
 class IntegerRange:
-    def __init__(self, includes: Set[Iterable[int]], excludes: Set[Iterable[int]]) -> None:
+    def __init__(self, includes: set[Iterable[int]], excludes: set[Iterable[int]]) -> None:
         self.includes = set(includes)
         self.excludes = set(excludes)
 
     @classmethod
-    def parse(cls, atoms: Iterable[Union[str, int]]) -> "IntegerRange":
-        includes: Set[Iterable[int]] = set()
-        excludes: Set[Iterable[int]] = set()
+    def parse(cls, atoms: Iterable[str | int]) -> IntegerRange:
+        includes: set[Iterable[int]] = set()
+        excludes: set[Iterable[int]] = set()
         for atom in atoms:
             if isinstance(atom, int):
                 includes.add((atom,))
@@ -32,7 +34,7 @@ class IntegerRange:
             raise ValueError(f"Not a valid range atom: {atom}")  # pragma: no cover
         return cls(includes=includes, excludes=excludes)
 
-    def as_set(self) -> Set[int]:
+    def as_set(self) -> set[int]:
         values = set()
         for inc in self.includes:
             values |= set(inc)

--- a/valohai_cli/settings/__init__.py
+++ b/valohai_cli/settings/__init__.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from valohai_cli.exceptions import APINotFoundError
 from valohai_cli.messages import error, info
@@ -19,18 +21,18 @@ class Settings:
     override_project = None
     api_user_agent_prefix = None
 
-    def __init__(self, persistence: Optional[Persistence] = None) -> None:
+    def __init__(self, persistence: Persistence | None = None) -> None:
         if not persistence:
             persistence = FilePersistence(get_filename=lambda: get_settings_file_name("config.json"))
 
         self.persistence: Persistence = persistence
-        self.overrides: Dict[str, Any] = {}
+        self.overrides: dict[str, Any] = {}
 
     def reset(self) -> None:
         self.override_project = None
         self.overrides.clear()
 
-    def _get(self, key: str, default: Any = None) -> Optional[Any]:
+    def _get(self, key: str, default: Any = None) -> Any | None:
         if key in self.overrides:
             return self.overrides[key]
         return self.persistence.get(key, default)
@@ -53,21 +55,21 @@ class Settings:
         return self.output_format == "human"
 
     @property
-    def user(self) -> Optional[dict]:
+    def user(self) -> dict | None:
         """
         The logged in user (dictionary or None).
         """
         return self._get("user")
 
     @property
-    def host(self) -> Optional[str]:
+    def host(self) -> str | None:
         """
         The host we're logged in to (string or None if not logged in).
         """
         return self._get("host")
 
     @property
-    def verify_ssl(self) -> Union[bool, str]:
+    def verify_ssl(self) -> bool | str:
         """
         Whether to verify SSL connections to the Valohai API, or a path to a CA bundle.
         """
@@ -77,7 +79,7 @@ class Settings:
         return str(value)
 
     @property
-    def token(self) -> Optional[str]:
+    def token(self) -> str | None:
         """
         The authentication token we have for the host we're logged in to.
         """
@@ -93,7 +95,7 @@ class Settings:
             return links
         return {}
 
-    def get_project(self, directory: str) -> Optional[Union["RemoteProject", "Project"]]:
+    def get_project(self, directory: str) -> RemoteProject | Project | None:
         """
         Get the Valohai project object for a directory context.
         The directory tree is walked upwards to find an actual linked directory.

--- a/valohai_cli/settings/persistence.py
+++ b/valohai_cli/settings/persistence.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import codecs
 import contextlib
 import json
 import os
 from errno import ENOENT
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 
 class Persistence:
-    def __init__(self, data: Optional[dict] = None) -> None:
+    def __init__(self, data: dict | None = None) -> None:
         self._data = data
 
     @property
@@ -16,10 +18,10 @@ class Persistence:
             self._data = {}
         return self._data
 
-    def update(self, data: Optional[dict] = None, **kwargs: Any) -> None:
+    def update(self, data: dict | None = None, **kwargs: Any) -> None:
         self.data.update((data or {}), **kwargs)
 
-    def get(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
+    def get(self, key: str, default: Any | None = None) -> Any | None:
         return self.data.get(key, default)
 
     def set(self, key: str, value: Any) -> None:

--- a/valohai_cli/table.py
+++ b/valohai_cli/table.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import json
 import shutil
 import sys
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Type, Union
+from collections.abc import Iterable, Sequence
+from typing import Any, Callable
 
 import click
 
@@ -11,13 +14,13 @@ TABLE_FORMATS = ("human", "csv", "tsv", "scsv", "psv", "json")
 SV_SEPARATORS = {"csv": ",", "tsv": "\t", "scsv": ";", "psv": "|"}
 
 
-def n_str(s: Union[float, str, int]) -> str:
+def n_str(s: float | str | int) -> str:
     if s is None:
         return ""
     return str(s).replace("\n", " ")
 
 
-def _format(datum: Union[Tuple[str, Any], str], width: Optional[int], allow_rjust: bool = True) -> str:
+def _format(datum: tuple[str, Any] | str, width: int | None, allow_rjust: bool = True) -> str:
     if isinstance(datum, tuple):
         datum, datatype = datum
     else:
@@ -60,7 +63,7 @@ class HumanTableFormatter:
 
         self.vertical_format = sum(self.column_widths) >= self.terminal_width
 
-    def _generate_vertical(self) -> Iterable[Tuple[bool, str]]:
+    def _generate_vertical(self) -> Iterable[tuple[bool, str]]:
         header_width = max(len(header) for header in self.headers)
         for row in self.printable_data:
             for header, value in zip(self.headers, row):
@@ -93,14 +96,14 @@ class HumanTableFormatter:
             self._echo_horizontal()
 
 
-StringAndType = Tuple[str, Type]
+StringAndType = tuple[str, type]
 
 
 def pluck_printable_data(
     data: Sequence[dict],
     columns: Sequence[str],
     col_formatter: Callable[[Any], StringAndType],
-) -> Iterable[List[StringAndType]]:
+) -> Iterable[list[StringAndType]]:
     for datum in data:
         yield [col_formatter(col_val) for col_val in (datum.get(column) for column in columns)]
 
@@ -108,8 +111,8 @@ def pluck_printable_data(
 def print_table(
     data: Any,
     columns: Sequence[str] = (),
-    headers: Optional[Sequence[str]] = None,
-    format: Optional[str] = None,
+    headers: Sequence[str] | None = None,
+    format: str | None = None,
     **kwargs: Any,
 ) -> None:
     if isinstance(data, dict) and not columns:

--- a/valohai_cli/tui.py
+++ b/valohai_cli/tui.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import math
 import shutil
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable
 
 import click
 
@@ -9,8 +11,8 @@ from valohai_cli.utils import force_text
 
 
 class LayoutElement:
-    style: Dict[str, Any] = {}
-    layout: "Layout"
+    style: dict[str, Any] = {}
+    layout: Layout
 
     def draw(self) -> None:
         raise NotImplementedError(f"{self.__class__} must implement draw()")
@@ -21,7 +23,7 @@ class Divider(LayoutElement):
     Full-width divider.
     """
 
-    def __init__(self, ch: str = "#", style: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, ch: str = "#", style: dict[str, Any] | None = None) -> None:
         """
         :param ch: The character (or characters) to fill the line with
         :param style: Click style dictionary
@@ -39,14 +41,14 @@ class Flex(LayoutElement):
     A columnar layout element.
     """
 
-    aligners: Dict[str, Callable[[str, int], str]] = {
+    aligners: dict[str, Callable[[str, int], str]] = {
         "left": lambda content, width: content.ljust(width),
         "right": lambda content, width: content.rjust(width),
         "center": lambda content, width: content.center(width),
     }
 
-    def __init__(self, style: Optional[Dict[str, Any]] = None) -> None:
-        self.cells: List[dict] = []
+    def __init__(self, style: dict[str, Any] | None = None) -> None:
+        self.cells: list[dict] = []
         self.style = style or {}
 
     def add(
@@ -54,9 +56,9 @@ class Flex(LayoutElement):
         content: str = "",
         *,
         flex: int = 1,
-        style: Optional[dict] = None,
+        style: dict | None = None,
         align: str = "left",
-    ) -> "Flex":
+    ) -> Flex:
         """
         Add a content column to the flex.
 
@@ -104,10 +106,10 @@ class Layout:
     """
 
     def __init__(self) -> None:
-        self.rows: List[LayoutElement] = []
+        self.rows: list[LayoutElement] = []
         self.width, self.height = shutil.get_terminal_size()
 
-    def add(self, element: LayoutElement) -> "Layout":
+    def add(self, element: LayoutElement) -> Layout:
         """
         Add a LayoutElement to the Layout.
 

--- a/valohai_cli/utils/__init__.py
+++ b/valohai_cli/utils/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 import os
 import random
@@ -6,7 +8,8 @@ import string
 import time
 import unicodedata
 import webbrowser
-from typing import Any, Callable, Dict, Iterable, Iterator, Tuple, Type, TypeVar, Union
+from collections.abc import Iterable, Iterator
+from typing import Any, Callable, TypeVar
 
 import click
 
@@ -41,7 +44,7 @@ def get_random_string(length: int = 12, keyspace: str = (string.ascii_letters + 
     return "".join(random.choice(keyspace) for x in range(length))
 
 
-def force_text(v: Union[str, bytes], encoding: str = "UTF-8", errors: str = "strict") -> str:
+def force_text(v: str | bytes, encoding: str = "UTF-8", errors: str = "strict") -> str:
     if isinstance(v, str):
         return v
     elif isinstance(v, bytes):
@@ -49,7 +52,7 @@ def force_text(v: Union[str, bytes], encoding: str = "UTF-8", errors: str = "str
     return str(v)
 
 
-def force_bytes(v: Union[str, int], encoding: str = "UTF-8", errors: str = "strict") -> bytes:
+def force_bytes(v: str | int, encoding: str = "UTF-8", errors: str = "strict") -> bytes:
     if isinstance(v, bytes):
         return v
     return str(v).encode(encoding, errors)
@@ -59,7 +62,7 @@ def humanize_identifier(identifier: str) -> str:
     return re.sub("[-_]+", " ", force_text(identifier)).strip()
 
 
-extension_to_interpreter: Dict[str, str] = {
+extension_to_interpreter: dict[str, str] = {
     ".lua": "lua",
     ".py": "python",
     ".rb": "ruby",
@@ -67,7 +70,7 @@ extension_to_interpreter: Dict[str, str] = {
 }
 
 
-def find_scripts(directory: str) -> Iterator[Tuple[str, str]]:
+def find_scripts(directory: str) -> Iterator[tuple[str, str]]:
     """
     Yield pairs of (interpreter, filename) for scripts found in `directory`.
 
@@ -80,7 +83,7 @@ def find_scripts(directory: str) -> Iterator[Tuple[str, str]]:
             yield (interpreter, os.path.basename(filename))
 
 
-def open_browser(object: Dict[str, Any], url_name: str = "display") -> bool:
+def open_browser(object: dict[str, Any], url_name: str = "display") -> bool:
     if "urls" not in object:
         return False
     url = object["urls"][url_name]
@@ -89,7 +92,7 @@ def open_browser(object: Dict[str, Any], url_name: str = "display") -> bool:
     return True
 
 
-def subset_keys(dict: Dict[Any, Any], keys: Iterable[Any]) -> Dict[Any, Any]:
+def subset_keys(dict: dict[Any, Any], keys: Iterable[Any]) -> dict[Any, Any]:
     return {key: dict[key] for key in dict if key in keys}
 
 
@@ -139,7 +142,7 @@ def parse_environment_variable_strings(
     envvar_strings: Iterable[str],
     *,
     coerce: Callable[[str], Any] = str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Parse a list of environment variable strings into a dict.
     """
@@ -163,8 +166,8 @@ T = TypeVar("T")
 def call_with_retry(
     func: Callable[[], T],
     retries: int = 3,
-    delay_range: Tuple[int, int] = (1, 5),
-    retry_on_exception_classes: Tuple[Type[Exception], ...] = (Exception,),
+    delay_range: tuple[int, int] = (1, 5),
+    retry_on_exception_classes: tuple[type[Exception], ...] = (Exception,),
 ) -> T:
     for attempt in range(retries):
         try:

--- a/valohai_cli/utils/api_error_utils.py
+++ b/valohai_cli/utils/api_error_utils.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import re
-from typing import Any, Callable, Iterable, Optional, Pattern, Union
+from collections.abc import Iterable
+from re import Pattern
+from typing import Any, Callable, Union
 
 StringOrPattern = Union[str, Pattern]
 
 
-def _match_string(s: Optional[str], pattern: StringOrPattern) -> bool:
+def _match_string(s: str | None, pattern: StringOrPattern) -> bool:
     if s is None:
         return False
     if isinstance(pattern, re.Pattern):
@@ -15,10 +19,10 @@ def _match_string(s: Optional[str], pattern: StringOrPattern) -> bool:
 def match_error(
     response_data: dict,
     *,
-    code: Optional[StringOrPattern] = None,
-    message: Optional[StringOrPattern] = None,
-    matcher: Optional[Callable] = None,
-) -> Optional[dict]:
+    code: StringOrPattern | None = None,
+    message: StringOrPattern | None = None,
+    matcher: Callable | None = None,
+) -> dict | None:
     if code and not _match_string(response_data.get("code"), code):
         return None
     if message and not _match_string(response_data.get("message"), message):
@@ -31,15 +35,15 @@ def match_error(
 def find_error(
     response_data: Any,
     *,
-    code: Optional[StringOrPattern] = None,
-    message: Optional[StringOrPattern] = None,
-    matcher: Optional[Callable] = None,
-) -> Optional[Any]:
+    code: StringOrPattern | None = None,
+    message: StringOrPattern | None = None,
+    matcher: Callable | None = None,
+) -> Any | None:
     if response_data is None:
         # Error not found in response
         return False
 
-    iterable: Optional[Iterable[Any]] = None
+    iterable: Iterable[Any] | None = None
     if isinstance(response_data, str):
         return match_error(
             {"message": response_data, "code": None},

--- a/valohai_cli/utils/cli_utils.py
+++ b/valohai_cli/utils/cli_utils.py
@@ -1,13 +1,10 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
 from typing import (
     Any,
     Callable,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
     TypeVar,
-    Union,
 )
 
 import click
@@ -26,9 +23,9 @@ def _default_name_formatter(option: Any) -> str:
 def prompt_from_list(
     options: Sequence[dict],
     prompt: str,
-    nonlist_validator: Optional[Callable[[str], Optional[Any]]] = None,
+    nonlist_validator: Callable[[str], Any | None] | None = None,
     name_formatter: Callable[[dict], str] = _default_name_formatter,
-) -> Union[Any, dict]:
+) -> Any | dict:
     for i, option in enumerate(options, 1):
         number_prefix = click.style(f"[{i:3d}]", fg="cyan")
         description_suffix = (
@@ -51,11 +48,11 @@ def prompt_from_list(
 
 
 class HelpfulArgument(click.Argument):
-    def __init__(self, param_decls: List[str], help: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, param_decls: list[str], help: str | None = None, **kwargs: Any) -> None:
         self.help = help
         super().__init__(param_decls, **kwargs)
 
-    def get_help_record(self, ctx: click.Context) -> Optional[Tuple[str, str]]:  # noqa: ARG002
+    def get_help_record(self, ctx: click.Context) -> tuple[str, str] | None:  # noqa: ARG002
         if self.name and self.help:
             return (self.name, self.help)
         return None

--- a/valohai_cli/utils/commits.py
+++ b/valohai_cli/utils/commits.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from __future__ import annotations
 
 import click
 from click import get_current_context
@@ -14,10 +14,10 @@ from valohai_cli.models.remote_project import RemoteProject
 
 
 def create_or_resolve_commit(
-    project: Union[RemoteProject, Project],
+    project: RemoteProject | Project,
     *,
-    commit: Optional[str],
-    yaml_path: Optional[str],
+    commit: str | None,
+    yaml_path: str | None,
     adhoc: bool,
     validate_adhoc_commit: bool = True,
     allow_git_packaging: bool = True,
@@ -42,7 +42,7 @@ def create_or_resolve_commit(
     return resolve_commit(commit, project)
 
 
-def get_git_commit(project: Project) -> Optional[str]:
+def get_git_commit(project: Project) -> str | None:
     try:
         return git.get_current_commit(project.directory)
     except NoGitRepo:
@@ -55,7 +55,7 @@ def get_git_commit(project: Project) -> Optional[str]:
         return None
 
 
-def resolve_commit(commit_identifier: Optional[str], project: Project) -> str:
+def resolve_commit(commit_identifier: str | None, project: Project) -> str:
     matching_commits = []
     if commit_identifier and commit_identifier.startswith("~"):
         # Assume ad-hoc commits are qualified already
@@ -87,7 +87,7 @@ def resolve_commit(commit_identifier: Optional[str], project: Project) -> str:
     return resolved_commit_identifier
 
 
-def fetch_latest_commits(commit_identifier: Optional[str]) -> List[dict]:
+def fetch_latest_commits(commit_identifier: str | None) -> list[dict]:
     ctx = get_current_context(silent=True)
     ctx.invoke(fetch)
     project = get_project(require=True)

--- a/valohai_cli/utils/error_fmt.py
+++ b/valohai_cli/utils/error_fmt.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Union
 
 import click
 
@@ -10,7 +10,7 @@ class ErrorFormatter:
     generic_dict_keys = ["non_field_errors", "detail", "error"]
 
     def __init__(self) -> None:
-        self.buffer: List[str] = []
+        self.buffer: list[str] = []
         self.level: int = 0
 
     def write(self, prefix: str, line: str) -> None:

--- a/valohai_cli/utils/file_size_format.py
+++ b/valohai_cli/utils/file_size_format.py
@@ -1,11 +1,11 @@
 # Adapted from Jinja2. Jinja2 is (c) 2017 by the Jinja Team, licensed under the BSD license.
-from typing import Union
+from __future__ import annotations
 
 binary_prefixes = ["KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
 decimal_prefixes = ["kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
 
 
-def filesizeformat(value: Union[int, float], binary: bool = False) -> str:
+def filesizeformat(value: int | float, binary: bool = False) -> str:
     """Format the value like a 'human-readable' file size (i.e. 13 kB,
     4.1 MB, 102 Bytes, etc).  Per default decimal prefixes are used (Mega,
     Giga, etc.), if the second parameter is set to `True` the binary

--- a/valohai_cli/utils/friendly_option_parser.py
+++ b/valohai_cli/utils/friendly_option_parser.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from click import NoSuchOption, OptionParser
 from click.parser import ParsingState
@@ -12,7 +12,7 @@ class FriendlyOptionParser(OptionParser):
     if the user has just misspelled an option name.
     """
 
-    def _match_long_opt(self, opt: str, explicit_value: Optional[str], state: ParsingState) -> None:
+    def _match_long_opt(self, opt: str, explicit_value: str | None, state: ParsingState) -> None:
         try:
             super()._match_long_opt(opt, explicit_value, state)
         except NoSuchOption as nse:

--- a/valohai_cli/utils/matching.py
+++ b/valohai_cli/utils/matching.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import re
-from typing import Any, Iterable, List, Optional, Union
+from collections.abc import Iterable
+from typing import Any
 
 import click
 
@@ -11,7 +14,7 @@ def match_prefix(
     choices: Iterable[Any],
     value: str,
     return_unique: bool = True,
-) -> Union[List[Any], Any, None]:
+) -> list[Any] | Any | None:
     """
     Match `value` in `choices` by case-insensitive prefix matching.
 
@@ -37,7 +40,7 @@ def match_from_list_with_error(
     options: Iterable[str],
     input: str,
     noun: str = "object",
-    param_hint: Optional[str] = None,
+    param_hint: str | None = None,
 ) -> str:
     """
     Wrap `match_prefix` and raise a pretty CLI error if no match is found, or if multiple matches are found.

--- a/valohai_cli/utils/ssh.py
+++ b/valohai_cli/utils/ssh.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 import json
 import os
 import pathlib
 import shutil
 import subprocess
 import time
+from collections.abc import Generator, Iterable, Iterator
 from dataclasses import dataclass
 from itertools import count
-from typing import Generator, Iterable, Iterator, Optional, Tuple
 
 import click
 
@@ -43,7 +45,7 @@ def make_ssh_connection(address: str, port: int, private_key_path: str) -> None:
     subprocess.run(ssh_command)
 
 
-def find_ssh_details(events: Iterable) -> Optional[Tuple[str, int]]:
+def find_ssh_details(events: Iterable) -> tuple[str, int] | None:
     prefix = "::ssh::"
     for event in events:
         if event["message"].startswith(prefix):
@@ -97,7 +99,7 @@ def select_private_key_from_possible_directories() -> str:
     return str(selected_key["name"])
 
 
-def fetch_status_events(execution: dict, first_n: Optional[int] = None) -> Generator:
+def fetch_status_events(execution: dict, first_n: int | None = None) -> Generator:
     params = {}
     if first_n is not None:
         params["limit"] = first_n
@@ -105,7 +107,7 @@ def fetch_status_events(execution: dict, first_n: Optional[int] = None) -> Gener
     yield from events_response.get("status_events", [])
 
 
-def get_ssh_details_from_execution(execution: dict) -> Tuple[str, int]:
+def get_ssh_details_from_execution(execution: dict) -> tuple[str, int]:
     events_response = fetch_status_events(execution, first_n=100)
     ssh_details = find_ssh_details(events_response)
     if not ssh_details:
@@ -115,7 +117,7 @@ def get_ssh_details_from_execution(execution: dict) -> Tuple[str, int]:
 
 def get_ssh_details_with_retry(
     counter: int,
-) -> Tuple[str, int]:
+) -> tuple[str, int]:
     """
     Fetch SSH details for a given counter, retrying until the execution has started.
 

--- a/valohai_cli/yaml_wizard.py
+++ b/valohai_cli/yaml_wizard.py
@@ -1,6 +1,5 @@
 import codecs
 import os
-from typing import List
 
 import click
 import requests
@@ -27,7 +26,7 @@ YAML_SKELLINGTON = """---
 """
 
 
-def get_image_suggestions() -> List[dict]:
+def get_image_suggestions() -> list[dict]:
     try:
         resp = requests.get("https://raw.githubusercontent.com/valohai/images/master/images.v2.yaml")
         resp.raise_for_status()


### PR DESCRIPTION
Python 3.8 has been EOL for 9 months. 

Previous versions of valohai-cli will of course continue to work with Python 3.8.