### PR TITLE
📝 Update Python version in docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,8 @@
 # Development
 
 ## Setting up
-This project is written in Python 3.8+.
+
+This project is written in Python 3.9+.
 
 ```bash
 pip install -e .
@@ -12,6 +13,7 @@ vh login --host http://localhost:8000
 ```
 
 ## Testing
+
 PyTest is used for running tests with the above mentioned Python versions. Development deps are in `requirements-dev.txt`.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ This is the command-line client for the [Valohai][vh] machine learning IaaS plat
 
 ## Installation
 
-`valohai-cli` supports Python 3.8 and higher.
+`valohai-cli` supports Python 3.9 and higher.
 
 - If you still need to run on Python 3.5, version 0.13.0 was the last one to support it.
 - If you still need to run on Python 3.6, version 0.23.0 was the last one to support it.
 - If you still need to run on Python 3.7, version 0.25.0 was the last one to support it.
+- If you still need to run on Python 3.8, version 0.33.0 was the last one to support it.
 
 ### System-wide or user-wide installation with pipx
 


### PR DESCRIPTION
In preparation for dropping Python 3.8 support in the next release, update the README version history for Python support, plus the current version in the dev readme.

No changelog update at this point – that should be done when preparing the next release.