### PR TITLE
Add commands to interact with model catalog

### DIFF
--- a/tests/commands/model/conftest.py
+++ b/tests/commands/model/conftest.py
@@ -1,0 +1,87 @@
+import pytest
+import requests_mock
+
+MODEL_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+MODEL_ID_2 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+VERSION_ID_1 = "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1"
+VERSION_ID_2 = "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv2"
+
+MODEL_DATA = {
+    "id": MODEL_ID,
+    "name": "sentiment-bert",
+    "slug": "sentiment-bert",
+    "owner": {"id": 1, "username": "acme-corp"},
+    "creator": {"id": 2, "username": "alice"},
+    "ctime": "2025-01-10T10:00:00Z",
+    "mtime": "2025-02-15T12:00:00Z",
+    "access_mode": "organization",
+    "tags": [],
+    "archived": False,
+    "version_summary": [],
+    "descriptions": [],
+    "url": f"https://app.valohai.com/api/v0/models/{MODEL_ID}/",
+    "n_comments": 0,
+    "associated_project_ids": [],
+    "associated_projects": [],
+    "teams": [],
+}
+
+VERSION_1 = {
+    "id": VERSION_ID_1,
+    "model": {"id": MODEL_ID, "name": "sentiment-bert", "slug": "sentiment-bert"},
+    "counter": 1,
+    "status": "Approved",
+    "source": {"type": "execution", "id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "title": "Train v1"},
+    "ctime": "2025-01-10T11:00:00Z",
+    "mtime": "2025-01-10T11:00:00Z",
+    "creator": {"id": 2, "username": "alice"},
+    "execution_count": 1,
+    "dataset_aliases": [],
+    "dataset_version": {
+        "name": "model-data-v1",
+        "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+        "ctime": "2025-01-10T10:00:00Z",
+    },
+    "tags": ["v1"],
+    "notes": [],
+    "descriptions": [],
+}
+
+VERSION_2 = {
+    "id": VERSION_ID_2,
+    "model": {"id": MODEL_ID, "name": "sentiment-bert", "slug": "sentiment-bert"},
+    "counter": 2,
+    "status": "Pending",
+    "source": {"type": "manual", "id": None, "title": None},
+    "ctime": "2025-02-15T12:00:00Z",
+    "mtime": "2025-02-15T12:00:00Z",
+    "creator": {"id": 2, "username": "alice"},
+    "execution_count": 0,
+    "dataset_aliases": [],
+    "dataset_version": {
+        "name": "model-data-v2",
+        "id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "ctime": "2025-02-15T11:00:00Z",
+    },
+    "tags": [],
+    "notes": [],
+    "descriptions": [],
+}
+
+
+def mock_model_api(
+    mocker: requests_mock.Mocker,
+    model: dict = MODEL_DATA,
+    versions: list | None = None,
+) -> None:
+    """Register mock responses for model detail, list, and optionally versions."""
+    mocker.get(f"https://app.valohai.com/api/v0/models/{model['id']}/", json=model)
+    mocker.get("https://app.valohai.com/api/v0/models/", json={"results": [model]})
+    if versions is not None:
+        mocker.get("https://app.valohai.com/api/v0/model-versions/", json={"results": versions})
+
+
+@pytest.fixture
+def mock_api():
+    with requests_mock.Mocker() as mocker:
+        yield mocker

--- a/tests/commands/model/test_describe.py
+++ b/tests/commands/model/test_describe.py
@@ -1,19 +1,9 @@
-import requests_mock
-
+from tests.commands.model.conftest import MODEL_DATA, MODEL_ID, VERSION_1, VERSION_2, mock_model_api
 from valohai_cli.commands.model.describe import describe
 
-MODEL_DETAIL_DATA = {
-    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-    "name": "sentiment-bert",
-    "slug": "sentiment-bert",
-    "owner": {"id": 1, "username": "acme-corp"},
-    "creator": {"id": 2, "username": "alice"},
-    "ctime": "2025-01-10T10:00:00Z",
-    "mtime": "2025-02-15T12:00:00Z",
-    "access_mode": "organization",
+DESCRIBE_MODEL = {
+    **MODEL_DATA,
     "tags": ["production", "nlp"],
-    "archived": False,
-    "version_summary": [],
     "descriptions": [
         {
             "title": "Overview",
@@ -21,115 +11,35 @@ MODEL_DETAIL_DATA = {
             "body": "A BERT model fine-tuned for sentiment analysis.",
         },
     ],
-    "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
-    "n_comments": 0,
-    "associated_project_ids": [],
     "associated_projects": [{"name": "my-nlp-project"}],
-    "teams": [],
 }
 
-MODEL_VERSIONS_DATA = [
-    {
-        "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1",
-        "model": {
-            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            "name": "sentiment-bert",
-            "slug": "sentiment-bert",
-        },
-        "counter": 1,
-        "status": "Approved",
-        "source": {"type": "execution", "id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "title": "Train v1"},
-        "ctime": "2025-01-10T11:00:00Z",
-        "mtime": "2025-01-10T11:00:00Z",
-        "creator": {"id": 2, "username": "alice"},
-        "execution_count": 1,
-        "dataset_aliases": [],
-        "dataset_version": {
-            "name": "model-data-v1",
-            "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
-            "ctime": "2025-01-10T10:00:00Z",
-        },
-        "tags": ["v1"],
-        "notes": [],
-        "descriptions": [],
-    },
-    {
-        "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv2",
-        "model": {
-            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            "name": "sentiment-bert",
-            "slug": "sentiment-bert",
-        },
-        "counter": 2,
-        "status": "Pending",
-        "source": {
-            "type": "pipeline",
-            "id": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
-            "title": "Retrain pipeline",
-        },
-        "ctime": "2025-02-15T12:00:00Z",
-        "mtime": "2025-02-15T12:00:00Z",
-        "creator": {"id": 2, "username": "alice"},
-        "execution_count": 3,
-        "dataset_aliases": [],
-        "dataset_version": {
-            "name": "model-data-v2",
-            "id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-            "ctime": "2025-02-15T11:00:00Z",
-        },
-        "tags": [],
-        "notes": [],
-        "descriptions": [],
-    },
-]
+DESCRIBE_VERSION_2 = {
+    **VERSION_2,
+    "source": {"type": "pipeline", "id": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee", "title": "Retrain pipeline"},
+}
 
 
-def _mock_model_apis(m):
-    m.get(
-        "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
-        json=MODEL_DETAIL_DATA,
-    )
-    m.get(
-        "https://app.valohai.com/api/v0/models/",
-        json={"results": [MODEL_DETAIL_DATA]},
-    )
-    m.get(
-        "https://app.valohai.com/api/v0/model-versions/",
-        json={"results": MODEL_VERSIONS_DATA},
-    )
+def test_describe_markdown_output(runner, logged_in, mock_api):
+    mock_model_api(mock_api, model=DESCRIBE_MODEL, versions=[VERSION_1, DESCRIBE_VERSION_2])
+    result = runner.invoke(describe, [MODEL_ID])
+    assert result.exit_code == 0
+    output = result.output
+    assert "# Model: sentiment-bert" in output
+    assert f"`{MODEL_ID}`" in output
+    assert "acme-corp" in output
+    assert "alice" in output
+    assert "`production`" in output
+    assert "`nlp`" in output
+    assert "A BERT model fine-tuned for sentiment analysis." in output
+    assert "my-nlp-project" in output
+    assert "| 1 | Approved | Train v1 | v1 | model-data-v1 |" in output
+    assert "| 2 | Pending | Retrain pipeline |  | model-data-v2 |" in output
 
 
-def test_describe_markdown_output(runner, logged_in):
-    with requests_mock.mock() as m:
-        _mock_model_apis(m)
-        result = runner.invoke(describe, ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"])
-        assert result.exit_code == 0
-        output = result.output
-        assert "# Model: sentiment-bert" in output
-        assert "`aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`" in output
-        assert "acme-corp" in output
-        assert "alice" in output
-        assert "`production`" in output
-        assert "`nlp`" in output
-        assert "A BERT model fine-tuned for sentiment analysis." in output
-        assert "my-nlp-project" in output
-        # Version table
-        assert "| 1 | Approved | Train v1 | v1 | model-data-v1 |" in output
-        assert "| 2 | Pending | Retrain pipeline |  | model-data-v2 |" in output
-
-
-def test_describe_no_versions(runner, logged_in):
-    with requests_mock.mock() as m:
-        # No need to mock model-versions since --no-versions skips the call
-        m.get(
-            "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
-            json=MODEL_DETAIL_DATA,
-        )
-        m.get(
-            "https://app.valohai.com/api/v0/models/",
-            json={"results": [MODEL_DETAIL_DATA]},
-        )
-        result = runner.invoke(describe, ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "--no-versions"])
-        assert result.exit_code == 0
-        assert "## Versions" not in result.output
-        assert "# Model: sentiment-bert" in result.output
+def test_describe_no_versions(runner, logged_in, mock_api):
+    mock_model_api(mock_api, model=DESCRIBE_MODEL)
+    result = runner.invoke(describe, [MODEL_ID, "--no-versions"])
+    assert result.exit_code == 0
+    assert "## Versions" not in result.output
+    assert "# Model: sentiment-bert" in result.output

--- a/tests/commands/model/test_describe.py
+++ b/tests/commands/model/test_describe.py
@@ -1,0 +1,135 @@
+import requests_mock
+
+from valohai_cli.commands.model.describe import describe
+
+MODEL_DETAIL_DATA = {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "name": "sentiment-bert",
+    "slug": "sentiment-bert",
+    "owner": {"id": 1, "username": "acme-corp"},
+    "creator": {"id": 2, "username": "alice"},
+    "ctime": "2025-01-10T10:00:00Z",
+    "mtime": "2025-02-15T12:00:00Z",
+    "access_mode": "organization",
+    "tags": ["production", "nlp"],
+    "archived": False,
+    "version_summary": [],
+    "descriptions": [
+        {
+            "title": "Overview",
+            "category": "Overview",
+            "body": "A BERT model fine-tuned for sentiment analysis.",
+        },
+    ],
+    "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
+    "n_comments": 0,
+    "associated_project_ids": [],
+    "associated_projects": [{"name": "my-nlp-project"}],
+    "teams": [],
+}
+
+MODEL_VERSIONS_DATA = [
+    {
+        "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1",
+        "model": {
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "name": "sentiment-bert",
+            "slug": "sentiment-bert",
+        },
+        "counter": 1,
+        "status": "Approved",
+        "source": {"type": "execution", "id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "title": "Train v1"},
+        "ctime": "2025-01-10T11:00:00Z",
+        "mtime": "2025-01-10T11:00:00Z",
+        "creator": {"id": 2, "username": "alice"},
+        "execution_count": 1,
+        "dataset_aliases": [],
+        "dataset_version": {
+            "name": "model-data-v1",
+            "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+            "ctime": "2025-01-10T10:00:00Z",
+        },
+        "tags": ["v1"],
+        "notes": [],
+        "descriptions": [],
+    },
+    {
+        "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv2",
+        "model": {
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "name": "sentiment-bert",
+            "slug": "sentiment-bert",
+        },
+        "counter": 2,
+        "status": "Pending",
+        "source": {
+            "type": "pipeline",
+            "id": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+            "title": "Retrain pipeline",
+        },
+        "ctime": "2025-02-15T12:00:00Z",
+        "mtime": "2025-02-15T12:00:00Z",
+        "creator": {"id": 2, "username": "alice"},
+        "execution_count": 3,
+        "dataset_aliases": [],
+        "dataset_version": {
+            "name": "model-data-v2",
+            "id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "ctime": "2025-02-15T11:00:00Z",
+        },
+        "tags": [],
+        "notes": [],
+        "descriptions": [],
+    },
+]
+
+
+def _mock_model_apis(m):
+    m.get(
+        "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
+        json=MODEL_DETAIL_DATA,
+    )
+    m.get(
+        "https://app.valohai.com/api/v0/models/",
+        json={"results": [MODEL_DETAIL_DATA]},
+    )
+    m.get(
+        "https://app.valohai.com/api/v0/model-versions/",
+        json={"results": MODEL_VERSIONS_DATA},
+    )
+
+
+def test_describe_markdown_output(runner, logged_in):
+    with requests_mock.mock() as m:
+        _mock_model_apis(m)
+        result = runner.invoke(describe, ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"])
+        assert result.exit_code == 0
+        output = result.output
+        assert "# Model: sentiment-bert" in output
+        assert "`aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa`" in output
+        assert "acme-corp" in output
+        assert "alice" in output
+        assert "`production`" in output
+        assert "`nlp`" in output
+        assert "A BERT model fine-tuned for sentiment analysis." in output
+        assert "my-nlp-project" in output
+        # Version table
+        assert "| 1 | Approved | Train v1 | v1 | model-data-v1 |" in output
+        assert "| 2 | Pending | Retrain pipeline |  | model-data-v2 |" in output
+
+
+def test_describe_no_versions(runner, logged_in):
+    with requests_mock.mock() as m:
+        # No need to mock model-versions since --no-versions skips the call
+        m.get(
+            "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
+            json=MODEL_DETAIL_DATA,
+        )
+        m.get(
+            "https://app.valohai.com/api/v0/models/",
+            json={"results": [MODEL_DETAIL_DATA]},
+        )
+        result = runner.invoke(describe, ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "--no-versions"])
+        assert result.exit_code == 0
+        assert "## Versions" not in result.output
+        assert "# Model: sentiment-bert" in result.output

--- a/tests/commands/model/test_info.py
+++ b/tests/commands/model/test_info.py
@@ -1,82 +1,26 @@
-import requests_mock
-
+from tests.commands.model.conftest import MODEL_DATA, MODEL_ID, VERSION_1, mock_model_api
 from valohai_cli.commands.model.info import info
 
-MODEL_DETAIL_DATA = {
-    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-    "name": "sentiment-bert",
-    "slug": "sentiment-bert",
-    "owner": {"id": 1, "username": "acme-corp"},
-    "creator": {"id": 2, "username": "alice"},
-    "ctime": "2025-01-10T10:00:00Z",
-    "mtime": "2025-02-15T12:00:00Z",
-    "access_mode": "organization",
+INFO_MODEL = {
+    **MODEL_DATA,
     "tags": ["production", "nlp"],
-    "version_summary": [],
-    "descriptions": {},
-    "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
-    "n_comments": 0,
-    "associated_project_ids": [],
     "associated_projects": [{"name": "my-nlp-project"}],
-    "teams": [],
-}
-
-MODEL_VERSION_DATA = {
-    "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvvv",
-    "model": {
-        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "name": "sentiment-bert",
-        "slug": "sentiment-bert",
-    },
-    "counter": 1,
-    "status": "Approved",
-    "source": {"type": "execution", "id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "title": "Train v1"},
-    "ctime": "2025-01-10T11:00:00Z",
-    "mtime": "2025-01-10T11:00:00Z",
-    "creator": {"id": 2, "username": "alice"},
-    "execution_count": 1,
-    "dataset_aliases": [],
-    "dataset_version": {
-        "name": "model-data-v1",
-        "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
-        "ctime": "2025-01-10T10:00:00Z",
-    },
-    "tags": ["v1"],
-    "notes": [],
-    "descriptions": [],
 }
 
 
-def _mock_model_apis(m):
-    m.get(
-        "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
-        json=MODEL_DETAIL_DATA,
-    )
-    m.get(
-        "https://app.valohai.com/api/v0/models/",
-        json={"results": [MODEL_DETAIL_DATA]},
-    )
-    m.get(
-        "https://app.valohai.com/api/v0/model-versions/",
-        json={"results": [MODEL_VERSION_DATA]},
-    )
+def test_model_info_by_id(runner, logged_in, mock_api):
+    mock_model_api(mock_api, model=INFO_MODEL, versions=[VERSION_1])
+    result = runner.invoke(info, [MODEL_ID])
+    assert result.exit_code == 0
+    assert "sentiment-bert" in result.output
+    assert "acme-corp" in result.output
+    assert "alice" in result.output
+    assert "Train v1" in result.output
+    assert "model-data-v1" in result.output
 
 
-def test_model_info_by_id(runner, logged_in):
-    with requests_mock.mock() as m:
-        _mock_model_apis(m)
-        result = runner.invoke(info, ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"])
-        assert result.exit_code == 0
-        assert "sentiment-bert" in result.output
-        assert "acme-corp" in result.output
-        assert "alice" in result.output
-        assert "Train v1" in result.output
-        assert "model-data-v1" in result.output
-
-
-def test_model_info_by_name(runner, logged_in):
-    with requests_mock.mock() as m:
-        _mock_model_apis(m)
-        result = runner.invoke(info, ["sentiment"])
-        assert result.exit_code == 0
-        assert "sentiment-bert" in result.output
+def test_model_info_by_name(runner, logged_in, mock_api):
+    mock_model_api(mock_api, model=INFO_MODEL, versions=[VERSION_1])
+    result = runner.invoke(info, ["sentiment"])
+    assert result.exit_code == 0
+    assert "sentiment-bert" in result.output

--- a/tests/commands/model/test_info.py
+++ b/tests/commands/model/test_info.py
@@ -1,0 +1,82 @@
+import requests_mock
+
+from valohai_cli.commands.model.info import info
+
+MODEL_DETAIL_DATA = {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "name": "sentiment-bert",
+    "slug": "sentiment-bert",
+    "owner": {"id": 1, "username": "acme-corp"},
+    "creator": {"id": 2, "username": "alice"},
+    "ctime": "2025-01-10T10:00:00Z",
+    "mtime": "2025-02-15T12:00:00Z",
+    "access_mode": "organization",
+    "tags": ["production", "nlp"],
+    "version_summary": [],
+    "descriptions": {},
+    "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
+    "n_comments": 0,
+    "associated_project_ids": [],
+    "associated_projects": [{"name": "my-nlp-project"}],
+    "teams": [],
+}
+
+MODEL_VERSION_DATA = {
+    "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvvv",
+    "model": {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "name": "sentiment-bert",
+        "slug": "sentiment-bert",
+    },
+    "counter": 1,
+    "status": "Approved",
+    "source": {"type": "execution", "id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "title": "Train v1"},
+    "ctime": "2025-01-10T11:00:00Z",
+    "mtime": "2025-01-10T11:00:00Z",
+    "creator": {"id": 2, "username": "alice"},
+    "execution_count": 1,
+    "dataset_aliases": [],
+    "dataset_version": {
+        "name": "model-data-v1",
+        "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+        "ctime": "2025-01-10T10:00:00Z",
+    },
+    "tags": ["v1"],
+    "notes": [],
+    "descriptions": [],
+}
+
+
+def _mock_model_apis(m):
+    m.get(
+        "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
+        json=MODEL_DETAIL_DATA,
+    )
+    m.get(
+        "https://app.valohai.com/api/v0/models/",
+        json={"results": [MODEL_DETAIL_DATA]},
+    )
+    m.get(
+        "https://app.valohai.com/api/v0/model-versions/",
+        json={"results": [MODEL_VERSION_DATA]},
+    )
+
+
+def test_model_info_by_id(runner, logged_in):
+    with requests_mock.mock() as m:
+        _mock_model_apis(m)
+        result = runner.invoke(info, ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"])
+        assert result.exit_code == 0
+        assert "sentiment-bert" in result.output
+        assert "acme-corp" in result.output
+        assert "alice" in result.output
+        assert "Train v1" in result.output
+        assert "model-data-v1" in result.output
+
+
+def test_model_info_by_name(runner, logged_in):
+    with requests_mock.mock() as m:
+        _mock_model_apis(m)
+        result = runner.invoke(info, ["sentiment"])
+        assert result.exit_code == 0
+        assert "sentiment-bert" in result.output

--- a/tests/commands/model/test_list.py
+++ b/tests/commands/model/test_list.py
@@ -1,0 +1,81 @@
+import requests_mock
+
+from valohai_cli.commands.model.list import list
+
+MODEL_LIST_DATA = [
+    {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "name": "sentiment-bert",
+        "slug": "sentiment-bert",
+        "owner": {"id": 1, "username": "acme-corp"},
+        "creator": {"id": 2, "username": "alice"},
+        "ctime": "2025-01-10T10:00:00Z",
+        "mtime": "2025-02-15T12:00:00Z",
+        "access_mode": "organization",
+        "tags": ["production", "nlp"],
+        "version_summary": [
+            {"counter": 1, "status": "Approved"},
+            {"counter": 2, "status": "Pending"},
+        ],
+        "descriptions": {},
+        "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
+        "n_comments": 0,
+        "associated_project_ids": [],
+        "associated_projects": [],
+    },
+    {
+        "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        "name": "image-classifier",
+        "slug": "image-classifier",
+        "owner": {"id": 1, "username": "acme-corp"},
+        "creator": {"id": 3, "username": "bob"},
+        "ctime": "2025-03-01T08:00:00Z",
+        "mtime": "2025-03-01T09:00:00Z",
+        "access_mode": "organization",
+        "tags": [],
+        "version_summary": [],
+        "descriptions": {},
+        "url": "https://app.valohai.com/api/v0/models/bbbbbbbb/",
+        "n_comments": 0,
+        "associated_project_ids": [],
+        "associated_projects": [],
+    },
+]
+
+
+def test_model_list(runner, logged_in):
+    with requests_mock.mock() as m:
+        m.get(
+            "https://app.valohai.com/api/v0/models/",
+            json={"results": MODEL_LIST_DATA},
+        )
+        result = runner.invoke(list)
+        assert result.exit_code == 0
+        assert "sentiment-bert" in result.output
+        assert "image-classifier" in result.output
+        assert "acme-corp" in result.output
+
+
+def test_model_list_quiet(runner, logged_in):
+    with requests_mock.mock() as m:
+        m.get(
+            "https://app.valohai.com/api/v0/models/",
+            json={"results": MODEL_LIST_DATA},
+        )
+        result = runner.invoke(list, ["--quiet"])
+        assert result.exit_code == 0
+        lines = result.output.strip().splitlines()
+        assert len(lines) == 2
+        assert "sentiment-bert\taaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" in lines[0]
+        assert "image-classifier\tbbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" in lines[1]
+
+
+def test_model_list_empty(runner, logged_in):
+    with requests_mock.mock() as m:
+        m.get(
+            "https://app.valohai.com/api/v0/models/",
+            json={"results": []},
+        )
+        result = runner.invoke(list)
+        assert result.exit_code == 0
+        assert "No models found" in result.output

--- a/tests/commands/model/test_list.py
+++ b/tests/commands/model/test_list.py
@@ -1,81 +1,50 @@
-import requests_mock
-
+from tests.commands.model.conftest import MODEL_DATA, MODEL_ID, MODEL_ID_2
 from valohai_cli.commands.model.list import list
 
 MODEL_LIST_DATA = [
     {
-        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "name": "sentiment-bert",
-        "slug": "sentiment-bert",
-        "owner": {"id": 1, "username": "acme-corp"},
-        "creator": {"id": 2, "username": "alice"},
-        "ctime": "2025-01-10T10:00:00Z",
-        "mtime": "2025-02-15T12:00:00Z",
-        "access_mode": "organization",
+        **MODEL_DATA,
         "tags": ["production", "nlp"],
         "version_summary": [
             {"counter": 1, "status": "Approved"},
             {"counter": 2, "status": "Pending"},
         ],
-        "descriptions": {},
-        "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
-        "n_comments": 0,
-        "associated_project_ids": [],
-        "associated_projects": [],
     },
     {
-        "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        **MODEL_DATA,
+        "id": MODEL_ID_2,
         "name": "image-classifier",
         "slug": "image-classifier",
-        "owner": {"id": 1, "username": "acme-corp"},
         "creator": {"id": 3, "username": "bob"},
         "ctime": "2025-03-01T08:00:00Z",
         "mtime": "2025-03-01T09:00:00Z",
-        "access_mode": "organization",
         "tags": [],
         "version_summary": [],
-        "descriptions": {},
-        "url": "https://app.valohai.com/api/v0/models/bbbbbbbb/",
-        "n_comments": 0,
-        "associated_project_ids": [],
-        "associated_projects": [],
     },
 ]
 
 
-def test_model_list(runner, logged_in):
-    with requests_mock.mock() as m:
-        m.get(
-            "https://app.valohai.com/api/v0/models/",
-            json={"results": MODEL_LIST_DATA},
-        )
-        result = runner.invoke(list)
-        assert result.exit_code == 0
-        assert "sentiment-bert" in result.output
-        assert "image-classifier" in result.output
-        assert "acme-corp" in result.output
+def test_model_list(runner, logged_in, mock_api):
+    mock_api.get("https://app.valohai.com/api/v0/models/", json={"results": MODEL_LIST_DATA})
+    result = runner.invoke(list)
+    assert result.exit_code == 0
+    assert "sentiment-bert" in result.output
+    assert "image-classifier" in result.output
+    assert "acme-corp" in result.output
 
 
-def test_model_list_quiet(runner, logged_in):
-    with requests_mock.mock() as m:
-        m.get(
-            "https://app.valohai.com/api/v0/models/",
-            json={"results": MODEL_LIST_DATA},
-        )
-        result = runner.invoke(list, ["--quiet"])
-        assert result.exit_code == 0
-        lines = result.output.strip().splitlines()
-        assert len(lines) == 2
-        assert "sentiment-bert\taaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" in lines[0]
-        assert "image-classifier\tbbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" in lines[1]
+def test_model_list_quiet(runner, logged_in, mock_api):
+    mock_api.get("https://app.valohai.com/api/v0/models/", json={"results": MODEL_LIST_DATA})
+    result = runner.invoke(list, ["--quiet"])
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert len(lines) == 2
+    assert f"sentiment-bert\t{MODEL_ID}" in lines[0]
+    assert f"image-classifier\t{MODEL_ID_2}" in lines[1]
 
 
-def test_model_list_empty(runner, logged_in):
-    with requests_mock.mock() as m:
-        m.get(
-            "https://app.valohai.com/api/v0/models/",
-            json={"results": []},
-        )
-        result = runner.invoke(list)
-        assert result.exit_code == 0
-        assert "No models found" in result.output
+def test_model_list_empty(runner, logged_in, mock_api):
+    mock_api.get("https://app.valohai.com/api/v0/models/", json={"results": []})
+    result = runner.invoke(list)
+    assert result.exit_code == 0
+    assert "No models found" in result.output

--- a/tests/commands/model/test_version.py
+++ b/tests/commands/model/test_version.py
@@ -1,0 +1,108 @@
+import requests_mock
+
+from valohai_cli.commands.model.version import version
+
+MODEL_DATA = {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "name": "sentiment-bert",
+    "slug": "sentiment-bert",
+    "owner": {"id": 1, "username": "acme-corp"},
+    "creator": {"id": 2, "username": "alice"},
+    "ctime": "2025-01-10T10:00:00Z",
+    "mtime": "2025-02-15T12:00:00Z",
+    "access_mode": "organization",
+    "tags": [],
+    "version_summary": [],
+    "descriptions": [],
+    "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
+    "n_comments": 0,
+    "associated_project_ids": [],
+    "associated_projects": [],
+}
+
+VERSION_DETAIL = {
+    "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1",
+    "model": {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "name": "sentiment-bert",
+        "slug": "sentiment-bert",
+    },
+    "counter": 1,
+    "status": "Approved",
+    "source": {"type": "execution", "id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "title": "Train v1"},
+    "ctime": "2025-01-10T11:00:00Z",
+    "mtime": "2025-01-10T11:00:00Z",
+    "creator": {"id": 2, "username": "alice"},
+    "execution_count": 1,
+    "dataset_aliases": [],
+    "dataset_version": {
+        "name": "model-data-v1",
+        "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+        "ctime": "2025-01-10T10:00:00Z",
+    },
+    "tags": ["v1"],
+    "notes": [],
+    "descriptions": [],
+}
+
+SOURCE_EXECUTIONS = [
+    {
+        "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        "counter": 42,
+        "status": "complete",
+        "step": "train-model",
+        "ctime": "2025-01-10T10:30:00Z",
+    },
+]
+
+SOURCE_DATA = [
+    {
+        "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+        "name": "model.pt",
+        "size": 1048576,
+        "ctime": "2025-01-10T10:45:00Z",
+    },
+]
+
+
+def _mock_apis(m):
+    m.get("https://app.valohai.com/api/v0/models/", json={"results": [MODEL_DATA]})
+    m.get(
+        "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
+        json=MODEL_DATA,
+    )
+    m.get("https://app.valohai.com/api/v0/model-versions/", json={"results": [VERSION_DETAIL]})
+    m.get(
+        "https://app.valohai.com/api/v0/model-versions/vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1/source-executions/",
+        json={"results": SOURCE_EXECUTIONS},
+    )
+    m.get(
+        "https://app.valohai.com/api/v0/model-versions/vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1/source-data/",
+        json={"results": SOURCE_DATA},
+    )
+
+
+def test_version_by_counter(runner, logged_in):
+    with requests_mock.mock() as m:
+        _mock_apis(m)
+        result = runner.invoke(version, ["sentiment", "1"])
+        assert result.exit_code == 0
+        assert "Train v1" in result.output
+        assert "model-data-v1" in result.output
+        assert "model.pt" in result.output
+        assert "train-model" in result.output
+
+
+def test_version_describe_mode(runner, logged_in):
+    with requests_mock.mock() as m:
+        _mock_apis(m)
+        result = runner.invoke(version, ["sentiment", "1", "--describe"])
+        assert result.exit_code == 0
+        output = result.output
+        assert "# Model Version: sentiment-bert #1" in output
+        assert "`vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1`" in output
+        assert "Approved" in output
+        assert "Train v1" in output
+        assert "model-data-v1" in output
+        assert "| 42 | complete | train-model |" in output
+        assert "| model.pt |" in output

--- a/tests/commands/model/test_version.py
+++ b/tests/commands/model/test_version.py
@@ -1,49 +1,5 @@
-import requests_mock
-
+from tests.commands.model.conftest import VERSION_1, VERSION_ID_1, mock_model_api
 from valohai_cli.commands.model.version import version
-
-MODEL_DATA = {
-    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-    "name": "sentiment-bert",
-    "slug": "sentiment-bert",
-    "owner": {"id": 1, "username": "acme-corp"},
-    "creator": {"id": 2, "username": "alice"},
-    "ctime": "2025-01-10T10:00:00Z",
-    "mtime": "2025-02-15T12:00:00Z",
-    "access_mode": "organization",
-    "tags": [],
-    "version_summary": [],
-    "descriptions": [],
-    "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
-    "n_comments": 0,
-    "associated_project_ids": [],
-    "associated_projects": [],
-}
-
-VERSION_DETAIL = {
-    "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1",
-    "model": {
-        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "name": "sentiment-bert",
-        "slug": "sentiment-bert",
-    },
-    "counter": 1,
-    "status": "Approved",
-    "source": {"type": "execution", "id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "title": "Train v1"},
-    "ctime": "2025-01-10T11:00:00Z",
-    "mtime": "2025-01-10T11:00:00Z",
-    "creator": {"id": 2, "username": "alice"},
-    "execution_count": 1,
-    "dataset_aliases": [],
-    "dataset_version": {
-        "name": "model-data-v1",
-        "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
-        "ctime": "2025-01-10T10:00:00Z",
-    },
-    "tags": ["v1"],
-    "notes": [],
-    "descriptions": [],
-}
 
 SOURCE_EXECUTIONS = [
     {
@@ -65,44 +21,38 @@ SOURCE_DATA = [
 ]
 
 
-def _mock_apis(m):
-    m.get("https://app.valohai.com/api/v0/models/", json={"results": [MODEL_DATA]})
+def _mock_version_sub_apis(m):
     m.get(
-        "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
-        json=MODEL_DATA,
-    )
-    m.get("https://app.valohai.com/api/v0/model-versions/", json={"results": [VERSION_DETAIL]})
-    m.get(
-        "https://app.valohai.com/api/v0/model-versions/vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1/source-executions/",
+        f"https://app.valohai.com/api/v0/model-versions/{VERSION_ID_1}/source-executions/",
         json={"results": SOURCE_EXECUTIONS},
     )
     m.get(
-        "https://app.valohai.com/api/v0/model-versions/vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1/source-data/",
+        f"https://app.valohai.com/api/v0/model-versions/{VERSION_ID_1}/source-data/",
         json={"results": SOURCE_DATA},
     )
 
 
-def test_version_by_counter(runner, logged_in):
-    with requests_mock.mock() as m:
-        _mock_apis(m)
-        result = runner.invoke(version, ["sentiment", "1"])
-        assert result.exit_code == 0
-        assert "Train v1" in result.output
-        assert "model-data-v1" in result.output
-        assert "model.pt" in result.output
-        assert "train-model" in result.output
+def test_version_by_counter(runner, logged_in, mock_api):
+    mock_model_api(mock_api, versions=[VERSION_1])
+    _mock_version_sub_apis(mock_api)
+    result = runner.invoke(version, ["sentiment", "1"])
+    assert result.exit_code == 0
+    assert "Train v1" in result.output
+    assert "model-data-v1" in result.output
+    assert "model.pt" in result.output
+    assert "train-model" in result.output
 
 
-def test_version_describe_mode(runner, logged_in):
-    with requests_mock.mock() as m:
-        _mock_apis(m)
-        result = runner.invoke(version, ["sentiment", "1", "--describe"])
-        assert result.exit_code == 0
-        output = result.output
-        assert "# Model Version: sentiment-bert #1" in output
-        assert "`vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1`" in output
-        assert "Approved" in output
-        assert "Train v1" in output
-        assert "model-data-v1" in output
-        assert "| 42 | complete | train-model |" in output
-        assert "| model.pt |" in output
+def test_version_describe_mode(runner, logged_in, mock_api):
+    mock_model_api(mock_api, versions=[VERSION_1])
+    _mock_version_sub_apis(mock_api)
+    result = runner.invoke(version, ["sentiment", "1", "--describe"])
+    assert result.exit_code == 0
+    output = result.output
+    assert "# Model Version: sentiment-bert #1" in output
+    assert f"`{VERSION_ID_1}`" in output
+    assert "Approved" in output
+    assert "Train v1" in output
+    assert "model-data-v1" in output
+    assert "| 42 | complete | train-model |" in output
+    assert "| model.pt |" in output

--- a/tests/commands/model/test_versions.py
+++ b/tests/commands/model/test_versions.py
@@ -1,110 +1,18 @@
-import requests_mock
-
+from tests.commands.model.conftest import VERSION_1, VERSION_2, mock_model_api
 from valohai_cli.commands.model.versions import versions
 
-MODEL_DATA = {
-    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-    "name": "sentiment-bert",
-    "slug": "sentiment-bert",
-    "owner": {"id": 1, "username": "acme-corp"},
-    "creator": {"id": 2, "username": "alice"},
-    "ctime": "2025-01-10T10:00:00Z",
-    "mtime": "2025-02-15T12:00:00Z",
-    "access_mode": "organization",
-    "tags": [],
-    "version_summary": [],
-    "descriptions": [],
-    "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
-    "n_comments": 0,
-    "associated_project_ids": [],
-    "associated_projects": [],
-}
 
-VERSION_DATA = [
-    {
-        "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1",
-        "model": {
-            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            "name": "sentiment-bert",
-            "slug": "sentiment-bert",
-        },
-        "counter": 1,
-        "status": "Approved",
-        "source": {"type": "execution", "id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "title": "Train v1"},
-        "ctime": "2025-01-10T11:00:00Z",
-        "mtime": "2025-01-10T11:00:00Z",
-        "creator": {"id": 2, "username": "alice"},
-        "execution_count": 1,
-        "dataset_aliases": [],
-        "dataset_version": {
-            "name": "model-data-v1",
-            "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
-            "ctime": "2025-01-10T10:00:00Z",
-        },
-        "tags": ["v1"],
-        "notes": [],
-        "descriptions": [],
-    },
-    {
-        "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv2",
-        "model": {
-            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-            "name": "sentiment-bert",
-            "slug": "sentiment-bert",
-        },
-        "counter": 2,
-        "status": "Pending",
-        "source": {"type": "manual", "id": None, "title": None},
-        "ctime": "2025-02-15T12:00:00Z",
-        "mtime": "2025-02-15T12:00:00Z",
-        "creator": {"id": 2, "username": "alice"},
-        "execution_count": 0,
-        "dataset_aliases": [],
-        "dataset_version": {
-            "name": "model-data-v2",
-            "id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-            "ctime": "2025-02-15T11:00:00Z",
-        },
-        "tags": [],
-        "notes": [],
-        "descriptions": [],
-    },
-]
+def test_versions_list(runner, logged_in, mock_api):
+    mock_model_api(mock_api, versions=[VERSION_1, VERSION_2])
+    result = runner.invoke(versions, ["sentiment"])
+    assert result.exit_code == 0
+    assert "Train v1" in result.output
+    assert "model-data-v1" in result.output
+    assert "model-data-v2" in result.output
 
 
-def _mock_apis(m):
-    m.get(
-        "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
-        json=MODEL_DATA,
-    )
-    m.get(
-        "https://app.valohai.com/api/v0/models/",
-        json={"results": [MODEL_DATA]},
-    )
-    m.get(
-        "https://app.valohai.com/api/v0/model-versions/",
-        json={"results": VERSION_DATA},
-    )
-
-
-def test_versions_list(runner, logged_in):
-    with requests_mock.mock() as m:
-        _mock_apis(m)
-        result = runner.invoke(versions, ["sentiment"])
-        assert result.exit_code == 0
-        assert "Train v1" in result.output
-        assert "model-data-v1" in result.output
-        assert "model-data-v2" in result.output
-
-
-def test_versions_empty(runner, logged_in):
-    with requests_mock.mock() as m:
-        m.get("https://app.valohai.com/api/v0/models/", json={"results": [MODEL_DATA]})
-        m.get(
-            "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
-            json=MODEL_DATA,
-        )
-        m.get("https://app.valohai.com/api/v0/model-versions/", json={"results": []})
-        result = runner.invoke(versions, ["sentiment"])
-        assert result.exit_code == 0
-        assert "No matching versions" in result.output
+def test_versions_empty(runner, logged_in, mock_api):
+    mock_model_api(mock_api, versions=[])
+    result = runner.invoke(versions, ["sentiment"])
+    assert result.exit_code == 0
+    assert "No matching versions" in result.output

--- a/tests/commands/model/test_versions.py
+++ b/tests/commands/model/test_versions.py
@@ -1,0 +1,110 @@
+import requests_mock
+
+from valohai_cli.commands.model.versions import versions
+
+MODEL_DATA = {
+    "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "name": "sentiment-bert",
+    "slug": "sentiment-bert",
+    "owner": {"id": 1, "username": "acme-corp"},
+    "creator": {"id": 2, "username": "alice"},
+    "ctime": "2025-01-10T10:00:00Z",
+    "mtime": "2025-02-15T12:00:00Z",
+    "access_mode": "organization",
+    "tags": [],
+    "version_summary": [],
+    "descriptions": [],
+    "url": "https://app.valohai.com/api/v0/models/aaaaaaaa/",
+    "n_comments": 0,
+    "associated_project_ids": [],
+    "associated_projects": [],
+}
+
+VERSION_DATA = [
+    {
+        "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv1",
+        "model": {
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "name": "sentiment-bert",
+            "slug": "sentiment-bert",
+        },
+        "counter": 1,
+        "status": "Approved",
+        "source": {"type": "execution", "id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "title": "Train v1"},
+        "ctime": "2025-01-10T11:00:00Z",
+        "mtime": "2025-01-10T11:00:00Z",
+        "creator": {"id": 2, "username": "alice"},
+        "execution_count": 1,
+        "dataset_aliases": [],
+        "dataset_version": {
+            "name": "model-data-v1",
+            "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+            "ctime": "2025-01-10T10:00:00Z",
+        },
+        "tags": ["v1"],
+        "notes": [],
+        "descriptions": [],
+    },
+    {
+        "id": "vvvvvvvv-vvvv-vvvv-vvvv-vvvvvvvvvvv2",
+        "model": {
+            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "name": "sentiment-bert",
+            "slug": "sentiment-bert",
+        },
+        "counter": 2,
+        "status": "Pending",
+        "source": {"type": "manual", "id": None, "title": None},
+        "ctime": "2025-02-15T12:00:00Z",
+        "mtime": "2025-02-15T12:00:00Z",
+        "creator": {"id": 2, "username": "alice"},
+        "execution_count": 0,
+        "dataset_aliases": [],
+        "dataset_version": {
+            "name": "model-data-v2",
+            "id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "ctime": "2025-02-15T11:00:00Z",
+        },
+        "tags": [],
+        "notes": [],
+        "descriptions": [],
+    },
+]
+
+
+def _mock_apis(m):
+    m.get(
+        "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
+        json=MODEL_DATA,
+    )
+    m.get(
+        "https://app.valohai.com/api/v0/models/",
+        json={"results": [MODEL_DATA]},
+    )
+    m.get(
+        "https://app.valohai.com/api/v0/model-versions/",
+        json={"results": VERSION_DATA},
+    )
+
+
+def test_versions_list(runner, logged_in):
+    with requests_mock.mock() as m:
+        _mock_apis(m)
+        result = runner.invoke(versions, ["sentiment"])
+        assert result.exit_code == 0
+        assert "Train v1" in result.output
+        assert "model-data-v1" in result.output
+        assert "model-data-v2" in result.output
+
+
+def test_versions_empty(runner, logged_in):
+    with requests_mock.mock() as m:
+        m.get("https://app.valohai.com/api/v0/models/", json={"results": [MODEL_DATA]})
+        m.get(
+            "https://app.valohai.com/api/v0/models/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/",
+            json=MODEL_DATA,
+        )
+        m.get("https://app.valohai.com/api/v0/model-versions/", json={"results": []})
+        result = runner.invoke(versions, ["sentiment"])
+        assert result.exit_code == 0
+        assert "No matching versions" in result.output

--- a/valohai_cli/commands/model/__init__.py
+++ b/valohai_cli/commands/model/__init__.py
@@ -1,0 +1,10 @@
+import click
+
+from valohai_cli.plugin_cli import PluginCLI
+
+
+@click.command(cls=PluginCLI, commands_module="valohai_cli.commands.model")
+def model() -> None:
+    """
+    Model catalog commands.
+    """

--- a/valohai_cli/commands/model/describe.py
+++ b/valohai_cli/commands/model/describe.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import click
+
+from valohai_cli.utils.model_utils import (
+    enrich_version,
+    fetch_model_versions,
+    generate_markdown_descriptions,
+    resolve_model,
+)
+
+
+@click.command()
+@click.argument("model_name_or_id")
+@click.option(
+    "--versions/--no-versions",
+    default=True,
+    help="Include version listing (default: yes)",
+)
+def describe(model_name_or_id: str, versions: bool) -> None:
+    """
+    Describe a model in Markdown format (for LLM agent use).
+
+    Outputs a structured Markdown document to stdout with the model's
+    metadata, tags, associated projects, descriptions, and version history.
+
+    MODEL_NAME_OR_ID can be a model name (prefix match) or UUID.
+    """
+    detail = resolve_model(model_name_or_id)
+    click.echo("\n".join(_generate_markdown(detail)))
+    if versions:
+        click.echo("\n".join(_generate_versions_section(detail)))
+
+
+def _generate_markdown(detail: dict) -> Iterator[str]:
+    yield f"# Model: {detail['name']}"
+    yield ""
+    yield from _generate_metadata_section(detail)
+    yield from _generate_tags_section(detail)
+    yield from generate_markdown_descriptions(detail.get("descriptions"))
+    yield from _generate_projects_section(detail)
+
+
+def _generate_versions_section(detail: dict) -> Iterator[str]:
+    version_list = fetch_model_versions(detail["id"])
+    if version_list:
+        yield "## Versions"
+        yield ""
+        yield "| # | Status | Source | Tags | Dataset Version | Created |"
+        yield "|---|--------|--------|------|-----------------|---------|"
+        for v in version_list:
+            enrich_version(v)
+            yield (
+                f"| {v.get('counter', '?')} | {v.get('status', '')} "
+                f"| {v['source_str']} | {v['tags_str']} "
+                f"| {v['dataset_version_name']} | {v.get('ctime', '')} |"
+            )
+        yield ""
+
+
+def _generate_projects_section(detail: dict) -> Iterator[str]:
+    if projects := detail.get("associated_projects", []):
+        yield "## Associated Projects"
+        yield ""
+        for proj in projects:
+            name = proj.get("name") or proj.get("id", str(proj))
+            yield f"- {name}"
+        yield ""
+
+
+def _generate_tags_section(detail: dict) -> Iterator[str]:
+    if tags := detail.get("tags", []):
+        yield "## Tags"
+        yield ""
+        yield ", ".join(f"`{t}`" for t in tags)
+        yield ""
+
+
+def _generate_metadata_section(detail: dict) -> Iterator[str]:
+    yield "## Metadata"
+    yield ""
+    yield f"- **ID:** `{detail['id']}`"
+    yield f"- **Slug:** `{detail.get('slug', '')}`"
+    yield f"- **Owner:** {detail.get('owner', {}).get('username', 'N/A')}"
+    yield f"- **Creator:** {detail.get('creator', {}).get('username', 'N/A')}"
+    yield f"- **Access mode:** {detail.get('access_mode', 'N/A')}"
+    yield f"- **Created:** {detail.get('ctime', 'N/A')}"
+    yield f"- **Modified:** {detail.get('mtime', 'N/A')}"
+    if detail.get("archived", False):
+        yield "- **Archived:** yes"
+    yield ""

--- a/valohai_cli/commands/model/info.py
+++ b/valohai_cli/commands/model/info.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import click
+
+from valohai_cli.settings import settings
+from valohai_cli.table import print_json, print_table
+from valohai_cli.utils import humanize_identifier
+from valohai_cli.utils.model_utils import (
+    fetch_model_versions,
+    print_version_table,
+    resolve_model,
+)
+
+
+@click.command()
+@click.argument("model_name_or_id")
+def info(model_name_or_id: str) -> None:
+    """
+    Show details about a model.
+
+    MODEL_NAME_OR_ID can be a model name (prefix match) or UUID.
+    """
+    detail = resolve_model(model_name_or_id)
+
+    if settings.output_format == "json":
+        return print_json(detail)
+
+    ignored_keys = {
+        "id",
+        "url",
+        "version_summary",
+        "associated_project_ids",
+        "associated_projects",
+        "teams",
+        "descriptions",
+    }
+
+    data = {
+        humanize_identifier(key): str(value)
+        for key, value in detail.items()
+        if key not in ignored_keys and not isinstance(value, (dict, list))
+    }
+    data["owner"] = detail.get("owner", {}).get("username", "")
+    data["creator"] = detail.get("creator", {}).get("username", "")
+
+    tags = detail.get("tags", [])
+    if tags:
+        data["tags"] = ", ".join(tags)
+
+    projects = detail.get("associated_projects", [])
+    if projects:
+        data["projects"] = ", ".join(p.get("name") or p.get("id", str(p)) for p in projects)
+
+    print_table(data)
+
+    versions = fetch_model_versions(detail["id"])
+    if versions:
+        click.echo()
+        print_version_table(versions)

--- a/valohai_cli/commands/model/list.py
+++ b/valohai_cli/commands/model/list.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from valohai_cli.api import request
+from valohai_cli.messages import info
+from valohai_cli.settings import settings
+from valohai_cli.table import print_json, print_table
+
+
+@click.command()
+@click.option(
+    "--count",
+    "--limit",
+    "-n",
+    type=int,
+    default=100,
+    help="How many models to show",
+)
+@click.option("--tag", "-t", multiple=True, help="Filter by tag")
+@click.option("--name", help="Filter by name (substring match)")
+@click.option("--quiet", "-q", is_flag=True, help="Print only names and IDs, one per line")
+def list(count: int, tag: tuple[str, ...], name: str | None, quiet: bool) -> None:
+    """
+    List models in the catalog.
+    """
+    params: dict[str, Any] = {
+        "limit": count,
+    }
+    if tag:
+        params["tags"] = ",".join(tag)
+    if name:
+        params["name"] = name
+
+    data = request("get", "/api/v0/models/", params=params).json()["results"]
+
+    if settings.output_format == "json":
+        return print_json(data)
+
+    if not data:
+        info("No models found.")
+        return
+
+    if quiet:
+        for item in data:
+            click.echo(f"{item['name']}\t{item['id']}")
+        return
+
+    for item in data:
+        item["owner_name"] = item.get("owner", {}).get("username", "")
+        tag_list = item.get("tags", [])
+        item["tags_str"] = ", ".join(tag_list) if tag_list else ""
+        versions = item.get("version_summary", [])
+        item["n_versions"] = str(len(versions))
+
+    print_table(
+        data,
+        columns=["name", "owner_name", "n_versions", "tags_str", "ctime"],
+        headers=["Name", "Owner", "Versions", "Tags", "Created"],
+    )

--- a/valohai_cli/commands/model/version.py
+++ b/valohai_cli/commands/model/version.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import click
+
+from valohai_cli.api import request
+from valohai_cli.settings import settings
+from valohai_cli.table import print_json, print_table
+from valohai_cli.utils import humanize_identifier
+from valohai_cli.utils.model_utils import (
+    format_version_source,
+    generate_markdown_descriptions,
+    resolve_model,
+    resolve_model_version,
+)
+
+
+@click.command()
+@click.argument("model_name_or_id")
+@click.argument("version_counter_or_id")
+@click.option(
+    "--describe",
+    "describe_mode",
+    is_flag=True,
+    help="Output as Markdown (for LLM agent use)",
+)
+def version(model_name_or_id: str, version_counter_or_id: str, describe_mode: bool) -> None:
+    """
+    Show details about a specific model version.
+
+    MODEL_NAME_OR_ID can be a model name (prefix match) or UUID.
+    VERSION_COUNTER_OR_ID can be a version counter number or UUID.
+    """
+    model = resolve_model(model_name_or_id)
+    ver = resolve_model_version(model["id"], version_counter_or_id)
+    ver_id = ver["id"]
+
+    source_exec_list = _fetch_optional_list(f"/api/v0/model-versions/{ver_id}/source-executions/")
+    source_data_list = _fetch_optional_list(f"/api/v0/model-versions/{ver_id}/source-data/")
+
+    if describe_mode:
+        click.echo("\n".join(_generate_markdown(ver, model, source_exec_list, source_data_list)))
+        return
+
+    if settings.output_format == "json":
+        return print_json({
+            "version": ver,
+            "source_executions": source_exec_list,
+            "source_data": source_data_list,
+        })
+
+    _print_table(ver, source_exec_list, source_data_list)
+
+
+def _fetch_optional_list(url: str) -> list[dict]:
+    """Fetch a list endpoint that may return 404, returning [] on 404."""
+    resp = request("get", url, handle_errors=False)
+    if resp.status_code == 404:
+        return []
+    resp.raise_for_status()
+    return resp.json().get("results", [])
+
+
+def _print_table(ver: dict, source_exec_list: list, source_data_list: list) -> None:
+    ignored_keys = {"id", "model", "dataset_aliases", "descriptions", "notes", "dataset_version"}
+
+    data = {
+        humanize_identifier(key): str(value)
+        for key, value in ver.items()
+        if key not in ignored_keys and not isinstance(value, (dict, list))
+    }
+    data["source"] = format_version_source(ver)
+    data["creator"] = ver.get("creator", {}).get("username", "")
+
+    dv = ver.get("dataset_version")
+    if dv:
+        data["dataset version"] = dv.get("name", "")
+
+    tags = ver.get("tags", [])
+    if tags:
+        data["tags"] = ", ".join(tags)
+
+    print_table(data)
+
+    if source_exec_list:
+        click.echo()
+        click.secho("Source Executions:", bold=True)
+        print_table(
+            source_exec_list,
+            columns=["counter", "status", "step", "ctime"],
+            headers=["#", "Status", "Step", "Created"],
+        )
+
+    if source_data_list:
+        click.echo()
+        click.secho("Source Data:", bold=True)
+        for d in source_data_list:
+            d["size_str"] = str(d.get("size", ""))
+        print_table(
+            source_data_list,
+            columns=["name", "size_str", "ctime"],
+            headers=["Name", "Size", "Created"],
+        )
+
+
+def _generate_markdown(
+    ver: dict,
+    model: dict,
+    source_exec_list: list,
+    source_data_list: list,
+) -> Iterator[str]:
+    yield f"# Model Version: {model['name']} #{ver.get('counter', '?')}"
+    yield ""
+
+    yield from _generate_metadata_section(model, ver)
+    yield from _generate_tags_section(ver)
+    yield from generate_markdown_descriptions(ver.get("descriptions"))
+    yield from _generate_notes_section(ver)
+    yield from _generate_source_execs_section(source_exec_list)
+    yield from _generate_source_data_section(source_data_list)
+
+
+def _generate_source_data_section(source_data_list: list) -> Iterator[str]:
+    if source_data_list:
+        yield "## Source Data"
+        yield ""
+        yield "| Name | Size | Created |"
+        yield "|------|------|---------|"
+        for d in source_data_list:
+            yield f"| {d.get('name', '')} | {d.get('size', '')} | {d.get('ctime', '')} |"
+        yield ""
+
+
+def _generate_source_execs_section(source_exec_list: list) -> Iterator[str]:
+    if source_exec_list:
+        yield "## Source Executions"
+        yield ""
+        yield "| # | Status | Step | Created |"
+        yield "|---|--------|------|---------|"
+        for ex in source_exec_list:
+            yield (
+                f"| {ex.get('counter', '?')} | {ex.get('status', '')} | {ex.get('step', '')} | {ex.get('ctime', '')} |"
+            )
+        yield ""
+
+
+def _generate_notes_section(ver: dict) -> Iterator[str]:
+    notes = ver.get("notes")
+    if not isinstance(notes, list):
+        return
+    non_empty_notes = [n for n in notes if isinstance(n, dict) and n.get("body")]
+    if not non_empty_notes:
+        return
+    yield "## Notes"
+    yield ""
+    for note in non_empty_notes:
+        heading = note.get("title", "")
+        if heading:
+            yield f"### {heading}"
+            yield ""
+        yield note["body"]
+        yield ""
+
+
+def _generate_tags_section(ver: dict) -> Iterator[str]:
+    if tags := ver.get("tags", []):
+        yield "## Tags"
+        yield ""
+        yield ", ".join(f"`{t}`" for t in tags)
+        yield ""
+
+
+def _generate_metadata_section(model: dict, ver: dict) -> Iterator[str]:
+    yield "## Metadata"
+    yield ""
+    yield f"- **Version ID:** `{ver['id']}`"
+    yield f"- **Model:** {model['name']} (`{model['id']}`)"
+    yield f"- **Counter:** {ver.get('counter', '?')}"
+    yield f"- **Status:** {ver.get('status', 'N/A')}"
+    source_str = format_version_source(ver)
+    source = ver.get("source", {})
+    if source_str:
+        yield f"- **Source:** {source_str} ({source.get('type', '')})"
+    yield f"- **Creator:** {ver.get('creator', {}).get('username', 'N/A')}"
+    yield f"- **Created:** {ver.get('ctime', 'N/A')}"
+    yield f"- **Modified:** {ver.get('mtime', 'N/A')}"
+    yield f"- **Execution count:** {ver.get('execution_count', 0)}"
+    dv = ver.get("dataset_version")
+    if dv:
+        yield f"- **Dataset version:** {dv.get('name', '')} (`{dv.get('id', '')}`)"
+    yield ""

--- a/valohai_cli/commands/model/versions.py
+++ b/valohai_cli/commands/model/versions.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from valohai_cli.messages import info
+from valohai_cli.settings import settings
+from valohai_cli.table import print_json
+from valohai_cli.utils.model_utils import (
+    fetch_model_versions,
+    print_version_table,
+    resolve_model,
+)
+
+
+@click.command()
+@click.argument("model_name_or_id")
+@click.option(
+    "--count",
+    "--limit",
+    "-n",
+    type=int,
+    default=100,
+    help="How many versions to show",
+)
+@click.option(
+    "--status",
+    "-s",
+    multiple=True,
+    type=click.Choice(["creating", "pending", "approved", "rejected"], case_sensitive=False),
+    help="Filter by status",
+)
+@click.option("--tag", "-t", multiple=True, help="Filter by tag")
+def versions(model_name_or_id: str, count: int, status: tuple[str, ...], tag: tuple[str, ...]) -> None:
+    """
+    List versions of a model.
+
+    MODEL_NAME_OR_ID can be a model name (prefix match) or UUID.
+    """
+    model = resolve_model(model_name_or_id)
+
+    params: dict[str, Any] = {"limit": count}
+    if status:
+        params["status"] = list(status)
+    if tag:
+        params["tags"] = ",".join(tag)
+
+    data = fetch_model_versions(model["id"], params)
+
+    if settings.output_format == "json":
+        return print_json(data)
+
+    if not data:
+        info(f"{model['name']}: No matching versions.")
+        return
+
+    print_version_table(data)

--- a/valohai_cli/utils/model_utils.py
+++ b/valohai_cli/utils/model_utils.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import click
+
+from valohai_cli.api import request
+from valohai_cli.table import print_table
+from valohai_cli.utils.matching import match_from_list_with_error
+
+VERSION_TABLE_COLUMNS = ["counter", "status", "source_str", "tags_str", "dataset_version_name", "ctime"]
+VERSION_TABLE_HEADERS = ["#", "Status", "Source", "Tags", "Dataset Version", "Created"]
+
+
+def resolve_model(name_or_id: str) -> dict:
+    """
+    Resolve a model by name (prefix match) or UUID.
+
+    Returns the full model detail dict from the API.
+    """
+    if _looks_like_uuid(name_or_id):
+        resp = request("get", f"/api/v0/models/{name_or_id}/", handle_errors=False)
+        if resp.status_code == 200:
+            return resp.json()
+
+    results = request(
+        "get",
+        "/api/v0/models/",
+        params={"limit": 200, "ordering": "name"},
+    ).json()["results"]
+
+    if not results:
+        raise click.ClickException("No models found.")
+
+    names = [m["name"] for m in results]
+    matched_name = match_from_list_with_error(names, name_or_id, noun="model")
+    model = next(m for m in results if m["name"] == matched_name)
+    return request("get", f"/api/v0/models/{model['id']}/").json()
+
+
+def resolve_model_version(model_id: str, counter_or_id: str) -> dict:
+    """
+    Resolve a model version by counter number or UUID.
+    """
+    if _looks_like_uuid(counter_or_id):
+        resp = request("get", f"/api/v0/model-versions/{counter_or_id}/", handle_errors=False)
+        if resp.status_code == 200:
+            return resp.json()
+
+    try:
+        counter = int(counter_or_id)
+    except ValueError:
+        raise click.ClickException(
+            f"{counter_or_id!r} is not a valid version counter or UUID.",
+        )
+
+    results = request(
+        "get",
+        "/api/v0/model-versions/",
+        params={"model": model_id, "counter": counter, "limit": 1},
+    ).json()["results"]
+
+    if not results:
+        raise click.ClickException(f"No version #{counter} found for this model.")
+
+    return results[0]
+
+
+def fetch_model_versions(model_id: str, params: dict[str, Any] | None = None) -> list[dict]:
+    """Fetch model versions from the API."""
+    base_params: dict[str, Any] = {"model": model_id, "limit": 100}
+    if params:
+        base_params.update(params)
+    return request("get", "/api/v0/model-versions/", params=base_params).json()["results"]
+
+
+def enrich_version(version: dict) -> None:
+    """Add display-friendly fields to a version dict, in place."""
+    version["source_str"] = format_version_source(version)
+    tags = version.get("tags", [])
+    version["tags_str"] = ", ".join(tags) if tags else ""
+    dv = version.get("dataset_version")
+    version["dataset_version_name"] = dv.get("name", "") if dv else ""
+
+
+def print_version_table(versions: list[dict]) -> None:
+    """Enrich and print a table of model versions."""
+    for v in versions:
+        enrich_version(v)
+    print_table(
+        versions,
+        columns=VERSION_TABLE_COLUMNS,
+        headers=VERSION_TABLE_HEADERS,
+    )
+
+
+def format_version_source(version: dict) -> str:
+    """Extract a human-readable source string from a version dict."""
+    source = version.get("source", {})
+    return source.get("title") or source.get("type", "")
+
+
+def generate_markdown_descriptions(descriptions: Any) -> Iterator[str]:
+    """Yield markdown-formatted description lines."""
+    if not descriptions or not isinstance(descriptions, list):
+        return
+    non_empty = [d for d in descriptions if d.get("body")]
+    if not non_empty:
+        return
+    yield "## Descriptions"
+    yield ""
+    for desc in non_empty:
+        heading = desc.get("title") or desc.get("category", "")
+        if heading:
+            yield f"### {heading}"
+            yield ""
+        yield desc["body"]
+        yield ""
+
+
+def _looks_like_uuid(s: str) -> bool:
+    """Check if a string looks like a UUID (with or without dashes)."""
+    clean = s.replace("-", "")
+    return len(clean) == 32 and all(c in "0123456789abcdef" for c in clean.lower())


### PR DESCRIPTION
Agents could be hinted to use `vh` with skills.

A suitably well-written model description is its weight in gold – this makes it nicer to try and ask an agent to, say, "find the latest version of the thingabob price prediction model to answer this query".