### PR TITLE
Add --reuse option to `vh pipe run`

### DIFF
--- a/tests/commands/pipeline/test_reuse.py
+++ b/tests/commands/pipeline/test_reuse.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import click
+import pytest
+
+from valohai_cli.commands.pipeline.run.reuse import apply_reuse_to_pipeline, parse_reuse_spec
+
+ALL_SOURCE_NODES = [
+    {"name": "pretrain", "id": "uuid-pretrain"},
+    {"name": "mangle", "id": "uuid-mangle"},
+    {"name": "train", "id": "uuid-train"},
+]
+
+
+def _make_nodes():
+    return [
+        {"type": "execution", "name": "pretrain", "template": {}},
+        {"type": "execution", "name": "mangle", "template": {}},
+        {"type": "execution", "name": "train", "template": {}},
+    ]
+
+
+def _make_project(source_nodes):
+    class MockProject:
+        def get_pipeline_from_counter(self, counter, params=None):
+            return {"nodes": source_nodes}
+
+    return MockProject()
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("latest:pretrain,mangle", ("latest", ["pretrain", "mangle"])),
+        ("42:train*", ("42", ["train*"])),
+        ("latest: pretrain , mangle ", ("latest", ["pretrain", "mangle"])),
+    ],
+)
+def test_parse_reuse_spec(spec, expected):
+    assert parse_reuse_spec(spec) == expected
+
+
+@pytest.mark.parametrize(
+    ("spec", "match"),
+    [
+        ("latest", "Invalid --reuse format"),
+        (":pretrain", "pipeline counter must not be empty"),
+        ("latest:", "no node globs specified"),
+    ],
+)
+def test_parse_reuse_spec_errors(spec, match):
+    with pytest.raises(click.UsageError, match=match):
+        parse_reuse_spec(spec)
+
+
+def test_apply_reuse_glob_matching():
+    nodes = _make_nodes()
+    project = _make_project(ALL_SOURCE_NODES)
+
+    apply_reuse_to_pipeline(
+        converted_nodes=nodes,
+        reuse_specs=["5:*train"],
+        project=project,
+    )
+
+    assert nodes[0] == {"type": "mimic", "name": "pretrain", "source": "uuid-pretrain"}
+    assert nodes[1]["type"] == "execution"
+    assert nodes[2] == {"type": "mimic", "name": "train", "source": "uuid-train"}
+
+
+def test_apply_reuse_node_not_in_source_raises():
+    nodes = _make_nodes()
+    project = _make_project([{"name": "train", "id": "uuid-train"}])
+
+    with pytest.raises(click.UsageError, match="not found in source pipeline"):
+        apply_reuse_to_pipeline(
+            converted_nodes=nodes,
+            reuse_specs=["latest:pretrain"],
+            project=project,
+        )

--- a/tests/commands/pipeline/test_run.py
+++ b/tests/commands/pipeline/test_run.py
@@ -1,9 +1,11 @@
+import re
+
 from click import BadParameter
 from pytest import raises
 
 from tests.commands.run_test_utils import RunAPIMock
 from tests.fixtures.config import PIPELINE_WITH_TASK_EXAMPLE, PIPELINE_YAML
-from tests.fixtures.data import PROJECT_DATA
+from tests.fixtures.data import PIPELINE_DATA, PROJECT_DATA
 from tests.utils import write_yaml_config
 from valohai_cli.commands.pipeline.run import run
 from valohai_cli.commands.pipeline.run.run import process_args
@@ -261,3 +263,39 @@ def test_process_args_parsing():
 
     result = process_args(["--node.flag"])
     assert result.node_parameters == {("node", "flag"): "true"}
+
+
+def test_pipeline_reuse(runner, logged_in_and_linked):
+    add_valid_pipeline_yaml()
+    args = ["--adhoc", "Training Pipeline", "--reuse=latest:preprocess"]
+    with RunAPIMock(num_pipeline_parameters=1) as mock_api:
+        # Register a GET handler for fetching the source pipeline by counter
+        mock_api.get(
+            re.compile(r"https://app\.valohai\.com/api/v0/pipelines/.+:latest/"),
+            json=PIPELINE_DATA,
+        )
+        output = runner.invoke(run, args).output
+        assert "Success" in output
+        assert "Reusing nodes: =latest: preprocess" in output
+
+        nodes = mock_api.last_create_pipeline_payload["nodes"]
+        preprocess_node = next(n for n in nodes if n["name"] == "preprocess")
+        assert preprocess_node["type"] == "mimic"
+        assert preprocess_node["source"] == "01744e18-c8c1-a267-44a2-5e7f0a86bf38"
+
+        # Other nodes should remain execution type
+        for node in nodes:
+            if node["name"] != "preprocess":
+                assert node["type"] == "execution"
+
+
+def test_pipeline_reuse_no_match(runner, logged_in_and_linked):
+    add_valid_pipeline_yaml()
+    args = ["--adhoc", "Training Pipeline", "--reuse=latest:nonexistent"]
+    with RunAPIMock(num_pipeline_parameters=1) as mock_api:
+        mock_api.get(
+            re.compile(r"https://app\.valohai\.com/api/v0/pipelines/.+:latest/"),
+            json=PIPELINE_DATA,
+        )
+        output = runner.invoke(run, args).output
+        assert "no nodes matched" in output

--- a/valohai_cli/commands/pipeline/run/reuse.py
+++ b/valohai_cli/commands/pipeline/run/reuse.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import fnmatch
+from typing import Any
+
+import click
+
+from valohai_cli.models.project import Project
+
+
+def parse_reuse_spec(spec: str) -> tuple[str, list[str]]:
+    """
+    Parse a --reuse spec of the form "pipeline-counter:glob1,glob2,...".
+
+    Returns (pipeline_counter, [glob1, glob2, ...]).
+    """
+    if ":" not in spec:
+        raise click.UsageError(
+            f"Invalid --reuse format: {spec!r}. Expected format: pipeline-counter:node-glob,node-glob,...",
+        )
+    counter_part, _, globs_part = spec.partition(":")
+    counter_part = counter_part.strip()
+    if not counter_part:
+        raise click.UsageError("--reuse: pipeline counter must not be empty")
+    globs = [g.strip() for g in globs_part.split(",") if g.strip()]
+    if not globs:
+        raise click.UsageError(f"--reuse: no node globs specified in {spec!r}")
+    return (counter_part, globs)
+
+
+def fetch_source_pipeline_nodes(project: Project, counter: str) -> dict[str, str]:
+    """
+    Fetch a pipeline by counter and return a mapping of node name -> node ID.
+    """
+    pipeline_data = project.get_pipeline_from_counter(counter)
+    nodes: dict[str, str] = {}
+    for node in pipeline_data.get("nodes", []):
+        name = node.get("name")
+        node_id = node.get("id")
+        if name and node_id:
+            nodes[name] = node_id
+    return nodes
+
+
+def apply_reuse_to_pipeline(
+    *,
+    converted_nodes: list[dict[str, Any]],
+    reuse_specs: list[str],
+    project: Project,
+) -> None:
+    """
+    For each --reuse spec, fetch the source pipeline and replace matching
+    nodes with mimic nodes referencing the source pipeline's nodes.
+    """
+    reuses = {}
+    for spec in reuse_specs:
+        counter, globs = parse_reuse_spec(spec)
+        source_nodes = fetch_source_pipeline_nodes(project, counter)
+        matched_any = False
+
+        for i, node in enumerate(converted_nodes):
+            node_name = node["name"]
+            if any(fnmatch.fnmatch(node_name, g) for g in globs):
+                if node_name not in source_nodes:
+                    raise click.UsageError(
+                        f"Node {node_name!r} matched by --reuse glob but not found "
+                        f"in source pipeline ={counter} "
+                        f"(available nodes: {sorted(source_nodes)})",
+                    )
+                converted_nodes[i] = {
+                    "type": "mimic",
+                    "name": node_name,
+                    "source": source_nodes[node_name],
+                }
+                reuses[node_name] = counter
+                matched_any = True
+
+        if not matched_any:
+            available = [n["name"] for n in converted_nodes]
+            raise click.UsageError(
+                f"--reuse={spec!r}: no nodes matched the given globs. Available nodes: {sorted(available)}",
+            )
+
+    if reuses:
+        reuse_descs = ", ".join(f"={counter}: {node_name}" for node_name, counter in sorted(reuses.items()))
+        click.echo(f"Reusing nodes: {reuse_descs}")

--- a/valohai_cli/commands/pipeline/run/run.py
+++ b/valohai_cli/commands/pipeline/run/run.py
@@ -11,9 +11,11 @@ from valohai_yaml.pipelines.conversion import ConvertedPipeline, PipelineConvert
 from valohai_yaml.utils import listify
 
 from valohai_cli.api import request
+from valohai_cli.commands.pipeline.run.reuse import apply_reuse_to_pipeline
 from valohai_cli.commands.pipeline.run.utils import match_pipeline
 from valohai_cli.ctx import get_project
 from valohai_cli.messages import success
+from valohai_cli.models.project import Project
 from valohai_cli.utils.commits import create_or_resolve_commit
 
 run_epilog = (
@@ -76,6 +78,18 @@ run_epilog = (
     default=None,
     help='Override environment UUID or slug',
 )
+@click.option(
+    "--reuse",
+    "reuse_specs",
+    multiple=True,
+    metavar="COUNTER:GLOB[,GLOB,...]",
+    help=(
+        "Reuse nodes from an existing pipeline run. "
+        "COUNTER is a pipeline counter (integer or 'latest'). "
+        "GLOBs are comma-separated node name patterns to reuse. "
+        "May be repeated. Example: --reuse=latest:pretrain,mangle"
+    ),
+)
 @click.argument(
     "args",
     nargs=-1,
@@ -94,6 +108,7 @@ def run(
     yaml: str | None,
     tags: list[str],
     environment: str | None,
+    reuse_specs: list[str],
     args: list[str],
 ) -> None:
     """
@@ -127,12 +142,13 @@ def run(
     start_pipeline(
         config=config,
         pipeline=pipeline,
-        project_id=project.id,
+        project=project,
         commit=commit,
         tags=tags,
         title=title,
         args=args,
         override_environment=environment,
+        reuse_specs=list(reuse_specs),
     )
 
 
@@ -208,9 +224,13 @@ def assign_node_parameters(
             )
         if conv_node["name"] != node_name:
             continue
+        node_type = conv_node.get("type")
+        # `--reuse` could have turned this node into a mimic
+        if node_type not in (ExecutionNode.type, TaskNode.type):
+            if node_type == "mimic":
+                node_type = "reused"
+            raise click.UsageError(f"Cannot set parameters for {node_type} node '{node_name}'.")
         node_defn = node_definitions[node_name]
-        if not isinstance(node_defn, (ExecutionNode, TaskNode)):
-            raise click.UsageError(f"Cannot set parameters for {node_defn.type} node '{node_name}'.")
         step = config.get_step_by(name=node_defn.step)
         if not step:
             raise ValueError(f"Step '{node_defn.step}' referenced by node '{node_name}' not defined.")
@@ -253,12 +273,13 @@ def start_pipeline(
     *,
     config: Config,
     pipeline: Pipeline,
-    project_id: str,
+    project: Project,
     commit: str,
     tags: list[str],
     args: list[str],
     title: str | None = None,
     override_environment: str | None = None,
+    reuse_specs: list[str] | None = None,
 ) -> None:
     if "--help" in args:
         raise click.UsageError("Sorry, --help is not presently supported when a pipeline name is specified.")
@@ -270,6 +291,13 @@ def start_pipeline(
         parameter_arguments=ppa.pipeline_parameters,
     )
     converted_pipeline = converter.convert_pipeline(pipeline)
+
+    if reuse_specs:
+        apply_reuse_to_pipeline(
+            converted_nodes=converted_pipeline["nodes"],
+            reuse_specs=reuse_specs,
+            project=project,
+        )
 
     if override_environment:
         for node in converted_pipeline["nodes"]:
@@ -293,7 +321,7 @@ def start_pipeline(
         raise click.UsageError(f"Unknown pipeline parameters: {unused_args}")
 
     payload: dict[str, Any] = {
-        "project": project_id,
+        "project": project.id,
         "title": title or pipeline.name,
         "tags": tags,
         **converted_pipeline,


### PR DESCRIPTION
Refs #372

Allows replacing selected pipeline nodes with mimic nodes that reference nodes from a previous pipeline run, avoiding re-execution of unchanged steps.

Usage: `vh pipe run MyPipeline --reuse=123:pretrain,mangle`
